### PR TITLE
Fix 2.7 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Getting Grapple installed is designed to be as simple as possible!
 ### Prerequisites
 ```
 Django  >= 2.2, <2.3
-wagtail >= 2.5, <2.7
+wagtail >= 2.5, <2.8
 ```
 
 ### Installation

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=2.2, <2.3
-    wagtail>=2.5, <2.7
+    wagtail>=2.5, <2.8
     graphene-django>=2.2.0
     graphql-core==2.2.1
     colorthief


### PR DESCRIPTION
Should fix #35

requirements.txt had Wagtail <2.8, but setup.cfg and the README still references 2.7