### PR TITLE
Allow turning off graphene’s ‘auto_camelcase’

### DIFF
--- a/docs/getting-started/examples.rst
+++ b/docs/getting-started/examples.rst
@@ -70,6 +70,6 @@ something like:
 
 **Next Steps**
 
-  * :doc:`../general-usage/types`
+  * :doc:`../general-usage/graphql-types`
   * :doc:`../general-usage/preview`
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -43,12 +43,16 @@ Add the GraphQL urls to your ``urls.py``:
    ]
 
 Done! Now you can proceed onto configuring your models to generate
-GraphQL types that adopt their stucture.
+GraphQL types that adopt their structure.
+
+By default, all field and argument names will be converted from `snake_case`
+to `camelCase`. To disable this behavior, set the `GRAPPLE_AUTO_CAMELCASE`
+setting to `False` on your project settings.
 
 * **Next Steps**
 
   * :doc:`examples`
-  * :doc:`../general-usage/types`
+  * :doc:`../general-usage/graphql-types`
 
 
-*Your graphql endpoint is available at http://localhost:8000/graphql/*
+*Your GraphQL endpoint is available at http://localhost:8000/graphql/*

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -2,11 +2,13 @@ from collections import OrderedDict
 from pydoc import locate
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from graphene.test import Client
 
 from wagtail.core.models import Page
+
+from grapple.schema import create_schema
 
 SCHEMA = locate(settings.GRAPHENE["SCHEMA"])
 
@@ -31,6 +33,35 @@ class PagesTest(BaseGrappleTest):
         self.assertEquals(type(executed["data"]), OrderedDict)
         self.assertEquals(type(executed["data"]["pages"]), list)
         self.assertEquals(type(executed["data"]["pages"][0]), OrderedDict)
+
+        pages = Page.objects.all()
+
+        self.assertEquals(len(executed["data"]["pages"]), pages.count())
+
+
+@override_settings(GRAPPLE_AUTO_CAMELCASE=False)
+class DisableAutoCamelCaseTest(TestCase):
+    def setUp(self):
+        schema = create_schema()
+        self.client = Client(schema)
+
+    def test_disable_auto_camel_case(self):
+        query = """
+        {
+            pages {
+                title
+                url_path
+            }
+        }
+        """
+
+        executed = self.client.execute(query)
+
+        self.assertEquals(type(executed["data"]), OrderedDict)
+        self.assertEquals(type(executed["data"]["pages"]), list)
+        self.assertEquals(type(executed["data"]["pages"][0]), OrderedDict)
+        self.assertEquals(type(executed["data"]["pages"][0]["title"]), str)
+        self.assertEquals(type(executed["data"]["pages"][0]["url_path"]), str)
 
         pages = Page.objects.all()
 

--- a/grapple/schema.py
+++ b/grapple/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from graphql.validation.rules import NoUnusedFragments, specified_rules
 
 # HACK: Remove NoUnusedFragments validator
@@ -45,7 +46,10 @@ def create_schema():
         pass
 
     return graphene.Schema(
-        query=Query, types=list(registry.models.values()), subscription=Subscription
+        query=Query,
+        subscription=Subscription,
+        types=list(registry.models.values()),
+        auto_camelcase=getattr(settings, 'GRAPPLE_AUTO_CAMELCASE', True)
     )
 
 


### PR DESCRIPTION
Fixes #40

Stops Graphene automatically converting Object fields from underscore case to camel case so:

```
{
  pages {
    ...on BlogPage {
      title
      bookFile {
        createdAt
      }
    }
  }
}
```

becomes...

```
{
  pages {
    ...on BlogPage {
      title
      book_file {
        created_at
      }
    }
  }
}
```

You simply just add `GRAPPLE_AUTO_CAMELCASE=False` to `base.py` settings file.