### PR TITLE
Add non-nullable support to fields

### DIFF
--- a/docs/general-usage/model-types.rst
+++ b/docs/general-usage/model-types.rst
@@ -1,26 +1,30 @@
 Model Types
 ===========
 What do we mean when we say types? Well in a Grapple context, a type is descriptor
-function that tells grapple what type a Django Models field is represented by 
+function that tells grapple what type a Django Models field is represented by
 in GraphQL.
 
 The field types below are simple to use and all work in the same way.
 We have created a bunch of built-in types for you to use in but you can always
-create your own using [Graphene](https://github.com/graphql-python/graphene) 
+create your own using [Graphene](https://github.com/graphql-python/graphene)
 (Grapples underlying library) and take advantage of Grapple's generic ``GraphQLField`` type.
 
 
 GraphQLString
 -------------
 .. module:: grapple.models
-.. class:: GraphQLString(field_name)
+.. class:: GraphQLString(field_name, required=False)
 
-    A basic field type is string. Commonly used for CharField, TextField, 
+    A basic field type is string. Commonly used for CharField, TextField,
     UrlField or any other Django field that returns a string as it's value.
 
     .. attribute:: GraphQLString.field_name
 
         This is the name of the class property used in your model definition.
+
+    .. attribute:: GraphQLString.required
+
+        Represents the field as non-nullable in the schema, This promises the client that it will have a value returned.
 
     In your models.py:
     ::
@@ -29,7 +33,7 @@ GraphQLString
 
         class BlogPage(Page):
             author = models.CharField(max_length=255)
-            
+
             graphql_fields = [
                 GraphQLString("author"),
             ]
@@ -37,7 +41,7 @@ GraphQLString
 
     Example query:
     ::
-    
+
         {
             page(slug: "example-blog-page") {
                 author
@@ -48,7 +52,7 @@ GraphQLString
 GraphQLCollection
 -------------
 .. module:: grapple.models
-.. class:: GraphQLCollection(nested_type, *args, **kwargs)
+.. class:: GraphQLCollection(nested_type, *args, required=False, item_required=False, **kwargs)
 
     A field type that wraps another model type in a list. Best suited for referencing Orderables (i.e. ForeignKey lists).
 
@@ -64,11 +68,19 @@ GraphQLCollection
 
         Any positional arguments that you want to pass on to the nested type.
 
+    .. attribute:: GraphQLString.required
+
+        Represents the list as non-nullable in the schema, This promises the client that it will have an array will be returned.
+
+    .. attribute:: GraphQLString.item_required
+
+        Represents the fields in the list as non-nullable in the schema, This promises the client that it will have an array will be returned items that won't be null.
+
     .. attribute:: **kwargs
 
-        Any keyword args that you want to pass on to the nested type. 
-        
-        One keyword argument that is more powerful with Collections is the `source` argument. With ``GraphQLCollection``, 
+        Any keyword args that you want to pass on to the nested type.
+
+        One keyword argument that is more powerful with Collections is the `source` argument. With ``GraphQLCollection``,
         You can pass a source string that is multiple layers deep and Grapple will handle the querying for you through
         multiple models (example below).
 
@@ -79,7 +91,7 @@ GraphQLCollection
 
         class BlogPage(Page):
             author = models.CharField(max_length=255)
-            
+
             graphql_fields = [
                 # Basic reference to Orderable model
                 GraphQLCollection(
@@ -99,7 +111,7 @@ GraphQLCollection
 
     Example query:
     ::
-    
+
         {
             page(slug: "example-blog-page") {
                 relatedUrls
@@ -113,17 +125,17 @@ GraphQLCollection
 GraphQLInt
 ----------
 .. module:: grapple.models
-.. class:: GraphQLInt(field_name)
+.. class:: GraphQLInt(field_name, required=False)
 
-    It's all fairly self explanatory but a `GraphQLInt` is used to 
-    serialize interger based Django fields such as IntegerField 
+    It's all fairly self explanatory but a `GraphQLInt` is used to
+    serialize interger based Django fields such as IntegerField
     or PositiveSmallIntegerField.
 
 
 GraphQLFloat
 ------------
 .. module:: grapple.models
-.. class:: GraphQLFloat(field_name)
+.. class:: GraphQLFloat(field_name, required=False)
 
     Like GraphQLInt, This field is used to serialize Float and Decimal fields.
 
@@ -131,22 +143,22 @@ GraphQLFloat
 GraphQLBoolean
 --------------
 .. module:: grapple.models
-.. class:: GraphQLBoolean(field_name)
+.. class:: GraphQLBoolean(field_name, required=False)
 
 
 GraphQLStreamfield
 ------------------
 .. module:: grapple.models
-.. class:: GraphQLStreamfield(field_name)
+.. class:: GraphQLStreamfield(field_name, required=False)
 
-This field type supports all built in Streamfield blocks. It also supports 
+This field type supports all built in Streamfield blocks. It also supports
 custom blocks built using StructBlock and the like.
 
 
 GraphQLSnippet
 --------------
 .. module:: grapple.models
-.. class:: GraphQLSnippet(field_name, snippet_modal)
+.. class:: GraphQLSnippet(field_name, snippet_modal, required=False)
 
     GraphQLSnippet is a little bit more complicated; You first need to define
     a `graphql_field` list on your snippet like you do your page. Then you need
@@ -220,9 +232,9 @@ GraphQLSnippet
 GraphQLForeignKey
 -----------------
 .. module:: grapple.models
-.. class:: GraphQLForeignKey(field_name, content_type, is_list = False)
+.. class:: GraphQLForeignKey(field_name, content_type, required=False)
 
-    GraphQLForeignKey is similar to GraphQLSnippet in that you pass a 
+    GraphQLForeignKey is similar to GraphQLSnippet in that you pass a
     ``field_name`` and ``content_type`` but you can also specify that the field
     is a list (for example when using ``Orderable``).
 
@@ -230,15 +242,9 @@ GraphQLForeignKey
 
         This is the name of the class property used in your model definition.
 
-    .. attribute:: GraphQLString.snippet_modal
+    .. attribute:: GraphQLString.field_type
 
-        String which defines the location of the snippet model you are referencing.
-
-    .. attribute:: GraphQLString.is_list
-    
-        Define whether this field should be a list (for example when using ``Orderable``).
-
-        .. warning:: ``is_list`` is now deprecated, please use ``GraphQLCollection`` field.
+        String which defines the location of the model model you are referencing. You can also pass the model class itself.
 
     ::
 
@@ -264,7 +270,7 @@ GraphQLImage
 ------------
 
 .. module:: grapple.models
-.. class:: GraphQLImage(field_name)
+.. class:: GraphQLImage(field_name, required=False)
 
     To serialize the WagtailImages or custom Image model then use this field
     type.
@@ -274,25 +280,9 @@ GraphQLDocument
 ---------------
 
 .. module:: grapple.models
-.. class:: GraphQLDocument(field_name)
+.. class:: GraphQLDocument(field_name, required=False)
 
-    To serialize the WagtailDocuments or custom Document model then use this 
+    To serialize the WagtailDocuments or custom Document model then use this
     field type.
-    
 
-GraphQLField
-------------
 
-.. module:: grapple.models
-.. class:: GraphQLForeignKey(field_name, graphene_type)
-
-    If you want to build your own (or use graphene's built-in types) then 
-    ``GraphQLField`` is what you need.
-
-    .. attribute:: GraphQLString.field_name
-
-        This is the name of the class property used in your model definition.
-
-    .. attribute:: GraphQLString.graphene_type
-
-        The graphene type that you want to use.

--- a/example/home/models.py
+++ b/example/home/models.py
@@ -99,10 +99,10 @@ class BlogPage(HeadlessPreviewMixin, Page):
 
     graphql_fields = [
         GraphQLString("heading"),
-        GraphQLString("date"),
+        GraphQLString("date", required=True),
         GraphQLStreamfield("body"),
         GraphQLCollection(
-            GraphQLForeignKey, "related_links", "home.blogpagerelatedlink"
+            GraphQLForeignKey, "related_links", "home.blogpagerelatedlink", required=True, item_required=True
         ),
         GraphQLCollection(GraphQLString, "related_urls", source="related_links.url"),
         GraphQLCollection(GraphQLString, "authors", source="authors.person.name"),

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -2,7 +2,6 @@ import os
 import base64
 import tempfile
 from PIL import Image, ImageFilter
-from colorthief import ColorThief
 from django.conf import settings
 from wagtail.search.index import class_is_indexed
 from wagtail.search.models import Query

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Django>=2.2,<2.3
-wagtail>=2.5,<2.8
+wagtail>=2.5,<2.9
 graphene-django==2.7.1
-colorthief
 channels==1.1.8
 asgi_redis
 graphql_ws
@@ -10,5 +9,4 @@ graphql-core==2.2.1
 factory-boy==2.12.0
 wagtail-factories==2.0.0
 django-cors-headers==3.0.2
-scour==0.37
 wagtail-headless-preview==0.1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,11 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=2.2, <2.3
-    wagtail>=2.5, <2.8
+    wagtail>=2.5, <2.9
     graphene-django==2.7.1
     graphql-core==2.2.1
-    colorthief
     channels==1.1.8
     asgi_redis
     graphql_ws
-    scour==0.37
     wagtail-headless-preview
+    graphene-django-optimizer==0.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,3 @@ install_requires =
     asgi_redis
     graphql_ws
     wagtail-headless-preview
-    graphene-django-optimizer==0.6.1


### PR DESCRIPTION
This feature was requested and add's support for https://docs.graphene-python.org/en/latest/types/list-and-nonnull/#nonnull

This is used like so:
```
GraphQLString("date", required=True),
```

or for collections:
```
GraphQLCollection(
            GraphQLForeignKey, "related_links", "home.blogpagerelatedlink", required=True, item_required=True
),
```
