### PR TITLE
Only enable GraphiQL when DEBUG=True

### DIFF
--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import render
 from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
@@ -20,9 +21,11 @@ def graphiql(request):
 
 # Traditional URL routing
 urlpatterns = [
-    url(r"^graphql", csrf_exempt(GraphQLView.as_view(graphiql=True))),
-    url(r"^graphiql", graphiql),
+    url(r"^graphql", csrf_exempt(GraphQLView.as_view(graphiql=settings.DEBUG))),
 ]
+
+if settings.DEBUG:
+    urlpatterns.append(url(r"^graphiql", graphiql))
 
 # Django Channel (v1.x) routing for subscription support
 channel_routing = [route_class(GraphQLSubscriptionConsumer, path=r"^/subscriptions")]

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -7,7 +7,6 @@ from graphene_django.views import GraphQLView
 from channels.routing import route_class
 from graphql_ws.django_channels import GraphQLSubscriptionConsumer
 
-
 def graphiql(request):
     graphiql_settings = {
         "GRAPHIQL_VERSION": "0.11.10",
@@ -20,11 +19,12 @@ def graphiql(request):
 
 
 # Traditional URL routing
+SHOULD_EXPOSE_GRAPHIQL = settings.DEBUG or getattr(settings, 'GRAPPLE_EXPOSE_GRAPHIQL', False)
 urlpatterns = [
-    url(r"^graphql", csrf_exempt(GraphQLView.as_view(graphiql=settings.DEBUG))),
+    url(r"^graphql", csrf_exempt(GraphQLView.as_view(graphiql=SHOULD_EXPOSE_GRAPHIQL))),
 ]
 
-if settings.DEBUG:
+if SHOULD_EXPOSE_GRAPHIQL:
     urlpatterns.append(url(r"^graphiql", graphiql))
 
 # Django Channel (v1.x) routing for subscription support


### PR DESCRIPTION
This only enables the GraphiQL IDE when the Django DEBUG variable is `True`. 