### PR TITLE
Upgrade GraphiQL dependencies

### DIFF
--- a/grapple/templates/grapple/graphiql.html
+++ b/grapple/templates/grapple/graphiql.html
@@ -5,22 +5,23 @@
   <title>GraphiQL</title>
   <meta name="robots" content="noindex" />
   <style>
-    html, body {
+    html, body, #graphiql {
       height: 100%;
       margin: 0;
       overflow: hidden;
       width: 100%;
     }
   </style>
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.css" rel="stylesheet" />
-  <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.0.0/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.0.0/react-dom.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.js"></script>
-  <script src="//unpkg.com/subscriptions-transport-ws@{{SUBSCRIPTIONS_TRANSPORT_VERSION}}/browser/client.js"></script>
-  <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
+  <link href="https://unpkg.com/graphiql@{{GRAPHIQL_VERSION}}/graphiql.min.css" rel="stylesheet" crossorigin="anonymous" />
+  <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react@{{REACT_VERSION}}/umd/react.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@{{REACT_VERSION}}/umd/react-dom.production.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/graphiql@{{GRAPHIQL_VERSION}}/graphiql.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/subscriptions-transport-ws@{{SUBSCRIPTIONS_TRANSPORT_VERSION}}/browser/client.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js" crossorigin="anonymous"></script>
 </head>
 <body>
+  <div id="graphiql"></div>
   <script>
     // Collect the URL parameters
     var parameters = {};
@@ -106,7 +107,7 @@
         onEditVariables: onEditVariables,
         onEditOperationName: onEditOperationName,
       }),
-      document.body
+      document.getElementById('graphiql')
     );
   </script>
 </body>

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -7,10 +7,12 @@ from graphene_django.views import GraphQLView
 from channels.routing import route_class
 from graphql_ws.django_channels import GraphQLSubscriptionConsumer
 
+
 def graphiql(request):
     graphiql_settings = {
-        "GRAPHIQL_VERSION": "0.11.10",
-        "SUBSCRIPTIONS_TRANSPORT_VERSION": "0.7.0",
+        "REACT_VERSION": "16.13.1",
+        "GRAPHIQL_VERSION": "0.17.5",
+        "SUBSCRIPTIONS_TRANSPORT_VERSION": "0.9.16",
         "subscriptionsEndpoint": "ws://localhost:8000/subscriptions",
         "endpointURL": "/graphql",
     }
@@ -19,13 +21,15 @@ def graphiql(request):
 
 
 # Traditional URL routing
-SHOULD_EXPOSE_GRAPHIQL = settings.DEBUG or getattr(settings, 'GRAPPLE_EXPOSE_GRAPHIQL', False)
+SHOULD_EXPOSE_GRAPHIQL = settings.DEBUG or getattr(
+    settings, 'GRAPPLE_EXPOSE_GRAPHIQL', False)
 urlpatterns = [
-    url(r"^graphql", csrf_exempt(GraphQLView.as_view(graphiql=SHOULD_EXPOSE_GRAPHIQL))),
+    url(r"^graphql", csrf_exempt(GraphQLView.as_view()))
 ]
 
 if SHOULD_EXPOSE_GRAPHIQL:
     urlpatterns.append(url(r"^graphiql", graphiql))
 
 # Django Channel (v1.x) routing for subscription support
-channel_routing = [route_class(GraphQLSubscriptionConsumer, path=r"^/subscriptions")]
+channel_routing = [route_class(
+    GraphQLSubscriptionConsumer, path=r"^/subscriptions")]


### PR DESCRIPTION
This upgrades all GraphiQL dependencies:
- graphiql: 0.13.0 -> 0.17.5
- react: 15.0.0 -> 16.13.1
- react-dom: 15.0.0 -> 16.13.1
- react-dom: 15.0.0 -> 16.13.1
- subscriptions-transport-ws: 0.7.0 -> 0.9.16

Also, the GraphiQL IDE on the `/graphql` endpoint was disabled because it uses an outdated version.
Basically `/graphql` for GET/POST GraphQL requests and `/graphiql` for the GraphiQL IDE.