### PR TITLE
PageInterface swap

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -22,7 +22,7 @@ from wagtail.snippets.models import get_snippet_models
 from .registry import registry
 from .types.documents import DocumentObjectType
 from .types.images import ImageObjectType
-from .types.pages import PageInterface, Page
+from .types.pages import Page, get_page_interface
 from .types.streamfield import generate_streamfield_union
 from .helpers import streamfield_types
 
@@ -416,7 +416,7 @@ def register_page_model(cls: Type[WagtailPage], type_prefix: str):
         return
 
     # Create a GQL type derived from page model.
-    page_node_type = build_node_type(cls, type_prefix, PageInterface, Page)
+    page_node_type = build_node_type(cls, type_prefix, get_page_interface(), Page)
 
     # Add page type to registry.
     if page_node_type:

--- a/grapple/models.py
+++ b/grapple/models.py
@@ -133,9 +133,9 @@ def GraphQLMedia(field_name: str, **kwargs):
 
 def GraphQLPage(field_name: str, **kwargs):
     def Mixin():
-        from .types.pages import PageInterface
+        from .types.pages import get_page_interface
 
-        return GraphQLField(field_name, PageInterface, **kwargs)
+        return GraphQLField(field_name, get_page_interface(), **kwargs)
 
     return Mixin
 

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -3,14 +3,14 @@ import graphene
 from django.conf import settings
 from wagtail.contrib.redirects.models import Redirect
 
-from .pages import PageInterface
+from .pages import get_page_interface
 
 
 class RedirectType(graphene.ObjectType):
     old_path = graphene.String(required=True)
     old_url = graphene.String(required=True)
     new_url = graphene.String(required=True)
-    page = graphene.Field(PageInterface)
+    page = graphene.Field(get_page_interface())
     is_permanent = graphene.Boolean(required=True)
 
     # Give old_path with BASE_URL attached.

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -4,16 +4,16 @@ from wagtail.core.models import Page as WagtailPage, Site
 from graphene_django.types import DjangoObjectType
 
 from ..utils import resolve_queryset
-from .pages import PageInterface, get_specific_page
+from .pages import get_specific_page, get_page_interface
 from .structures import QuerySetList
 
 
 class SiteObjectType(DjangoObjectType):
     pages = QuerySetList(
-        graphene.NonNull(lambda: PageInterface), enable_search=True, required=True
+        graphene.NonNull(get_page_interface), enable_search=True, required=True
     )
     page = graphene.Field(
-        PageInterface,
+        get_page_interface(),
         id=graphene.Int(),
         slug=graphene.String(),
         token=graphene.String(),

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -433,12 +433,12 @@ registry.streamfield_blocks.update(
 
 
 def register_streamfield_blocks():
-    from .pages import PageInterface
+    from .pages import get_page_interface
     from .documents import get_document_type
     from .images import get_image_type
 
     class PageChooserBlock(graphene.ObjectType):
-        page = graphene.Field(PageInterface, required=True)
+        page = graphene.Field(get_page_interface(), required=True)
 
         class Meta:
             interfaces = (StreamFieldInterface,)


### PR DESCRIPTION
This gives users the ability to swap the implementation of `PageInterface`.

An example use-case is to override the resolvers for the fields, for example, to allow API access to private pages based on current user's permissions, etc.

Usage:

```
# settings.py
GRAPPLE_PAGE_INTERFACE = "myproject.myapp.interfaces.MyPageInterface"
```
If not set, uses the default implementation

```
# myproject/myapp/interfaces.py
from grapple.types.pages import PageInterface

class MyPageInterface(PageInterface):
    def resolve_children(self, into, **kwargs):
        # alternative implementation of the `children` field resolver
        return ...
```