### PR TITLE
Check callable field sources before execution

### DIFF
--- a/example/home/blocks.py
+++ b/example/home/blocks.py
@@ -98,6 +98,21 @@ class TextAndButtonsBlock(blocks.StructBlock):
 
 
 @register_streamfield_block
+class BlockWithName(blocks.StructBlock):
+    """
+    wagtail.core.blocks.Block defines a name property inherited by all blocks.
+    Ensure that when we bind a block to "name" that the block's value is
+    returned in GraphQL queries.
+    """
+
+    name = blocks.TextBlock()
+
+    graphql_fields = [
+        GraphQLString("name"),
+    ]
+
+
+@register_streamfield_block
 class TextWithCallableBlock(blocks.StructBlock):
     text = blocks.CharBlock()
     integer = blocks.IntegerBlock()
@@ -235,3 +250,4 @@ class StreamFieldBlock(blocks.StreamBlock):
     text_and_buttons = TextAndButtonsBlock()
     page = blocks.PageChooserBlock()
     text_with_callable = TextWithCallableBlock()
+    block_with_name = BlockWithName()

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -91,6 +91,12 @@ class BlogTest(BaseGrappleTest):
                         },
                     },
                 ),
+                (
+                    "block_with_name",
+                    {
+                        "name": "Test Name",
+                    },
+                ),
                 ("text_with_callable", TextWithCallableBlockFactory()),
             ],
             parent=self.home,
@@ -618,6 +624,16 @@ class BlogTest(BaseGrappleTest):
                 button = query_blocks[0]["mainbutton"]
                 self.assertEquals(button["buttonText"], "Take me to the source")
                 self.assertEquals(button["buttonLink"], "https://wagtail.io/")
+
+    def test_block_with_name(self):
+        block_type = "BlockWithName"
+        block_query = "name"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                result = query_blocks[0][block_query]
+                self.assertEquals("Test Name", result)
 
     def test_empty_list_in_structblock(self):
         another_blog_post = BlogPageFactory(

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -393,7 +393,7 @@ def custom_cls_resolver(*, cls, graphql_field):
             return lambda self, instance, info, **kwargs: getattr(
                 klass, graphql_field.field_source
             )
-        else:
+        elif callable(getattr(cls, graphql_field.field_source)):
             return lambda self, instance, info, **kwargs: getattr(
                 klass, graphql_field.field_source
             )(values=get_all_field_values(instance=instance, cls=cls))
@@ -406,7 +406,7 @@ def custom_cls_resolver(*, cls, graphql_field):
             return lambda self, instance, info, **kwargs: getattr(
                 klass, graphql_field.field_name
             )
-        else:
+        elif callable(getattr(cls, graphql_field.field_name)):
             return lambda self, instance, info, **kwargs: getattr(
                 klass, graphql_field.field_name
             )(values=get_all_field_values(instance=instance, cls=cls))


### PR DESCRIPTION
Firstly thanks for this package! It's helped remove a lot of glue code from a project!

I've spotted some GraphQL queries raising `graphql.error.located_error.GraphQLLocatedError: 'str' object is not callable`.

I tracked it down to [`custom_cls_resolver`](https://github.com/torchbox/wagtail-grapple/blob/9b8a49c05ddc74673e980e6a359c9f642aae8877/grapple/actions.py#L385) where a check is performed to see whether the block's class has an attribute with the same name as the queried value, to support the [`grapple.models.GraphQLField(source=<attr-or-method>)`](https://wagtail-grapple.readthedocs.io/en/latest/general-usage/model-types.html#module-grapple.models) functionality.

The block I was querying contained a sub-block bound to `name` which during resolution, `custom_cls_resolver` would fetch the `name` attribute from [`wagtail.core.blocks.base.Block`](https://github.com/wagtail/wagtail/blob/62e1e4e838496fae4c2ec0b5265b28dfb5d57ce4/wagtail/core/blocks/base.py#L45) and attempt to execute it.

This PR adds a check to ensure that any attr is callable before attempting to execute it, allowing queries with blocks bound to `name` to resolve using the `streamfield_resolver`.