### PR TITLE
Feature/wagtail 3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        wagtail-version: ['2.14', '2.15', '2.16']
+        wagtail-version: ['2.14', '2.15', '2.16', '3.0']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        wagtail-version: ['2.14', '2.15', '2.16', '3.0']
+        wagtail-version: ['2.15', '2.16', '3.0']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Getting Grapple installed is designed to be as simple as possible!
 
 ```
 Django  >= 3.0, <4.0
-Wagtail >= 2.14, <2.17
+Wagtail >= 2.15, <4.0
 ```
 
 ### Installation
@@ -186,7 +186,7 @@ Wagtail Grapple supports:
 
 -   Django >= 3.0, < 4.0
 -   Python 3.7, 3.8, 3.9, and 3.10
--   Wagtail >= 2.14, < 2.17
+-   Wagtail >= 2.15, < 4.0
 
 ## License
 

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
@@ -22,6 +24,8 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 
 # Application definition
+
+WAGTAIL_CORE = "wagtail" if WAGTAIL_VERSION >= (3, 0) else "wagtail.core"
 
 INSTALLED_APPS = [
     "home",
@@ -38,7 +42,7 @@ INSTALLED_APPS = [
     "wagtail.images",
     "wagtail.search",
     "wagtail.admin",
-    "wagtail.core",
+    WAGTAIL_CORE,
     "wagtail.contrib.settings",
     "modelcluster",
     "wagtailmedia",

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -20,7 +20,11 @@ from django.test import RequestFactory, TestCase, override_settings
 from graphene.test import Client
 from home.factories import BlogPageFactory
 from home.models import HomePage
-from wagtail.core.models import Page, Site
+
+try:
+    from wagtail.models import Page, Site
+except ImportError:
+    from wagtail.core.models import Page, Site
 from wagtail.documents import get_document_model
 from wagtail.images import get_image_model
 from wagtailmedia.models import get_media_model
@@ -232,7 +236,8 @@ class PageUrlPathTest(BaseGrappleTest):
         self.assertEquals(int(page_data["id"]), home_child.id)
 
         with patch(
-            "wagtail.core.models.Site.find_for_request", return_value=another_site
+            f"{settings.WAGTAIL_CORE}.models.Site.find_for_request",
+            return_value=another_site,
         ):
             page_data = self._query_by_path("/child/", in_site=True)
             self.assertEquals(int(page_data["id"]), another_child.id)

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -3,7 +3,11 @@ from django.contrib import admin
 from django.urls import include, path
 from search import views as search_views
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+
+try:
+    from wagtail import urls as wagtail_urls
+except ImportError:
+    from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 from grapple import urls as grapple_urls

--- a/example/home/models.py
+++ b/example/home/models.py
@@ -5,10 +5,16 @@ from home.blocks import StreamFieldBlock
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
-from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, StreamFieldPanel
+
+try:
+    from wagtail.admin.panels import FieldPanel, InlinePanel
+    from wagtail.fields import StreamField
+    from wagtail.models import Orderable, Page
+except ImportError:
+    from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, StreamFieldPanel
+    from wagtail.core.fields import StreamField
+    from wagtail.core.models import Orderable, Page
 from wagtail.contrib.settings.models import BaseSetting, register_setting
-from wagtail.core.fields import StreamField
-from wagtail.core.models import Orderable, Page
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
@@ -35,6 +41,11 @@ from grapple.models import (
     GraphQLTag,
 )
 from grapple.utils import resolve_paginated_queryset
+
+try:
+    StreamFieldPanel
+except NameError:
+    StreamFieldPanel = FieldPanel
 
 document_model_string = getattr(
     settings, "WAGTAILDOCS_DOCUMENT_MODEL", "wagtaildocs.Document"

--- a/example/home/models.py
+++ b/example/home/models.py
@@ -42,11 +42,6 @@ from grapple.models import (
 )
 from grapple.utils import resolve_paginated_queryset
 
-try:
-    StreamFieldPanel
-except NameError:
-    StreamFieldPanel = FieldPanel
-
 document_model_string = getattr(
     settings, "WAGTAILDOCS_DOCUMENT_MODEL", "wagtaildocs.Document"
 )
@@ -117,7 +112,9 @@ class BlogPage(HeadlessPreviewMixin, Page):
     content_panels = Page.content_panels + [
         FieldPanel("date"),
         ImageChooserPanel("hero_image"),
-        StreamFieldPanel("body"),
+        FieldPanel("body")
+        if settings.WAGTAIL_VERSION >= (3, 0)
+        else StreamFieldPanel("body"),
         FieldPanel("tags"),
         InlinePanel("related_links", label="Related links"),
         InlinePanel("authors", label="Authors"),

--- a/example/home/mutations.py
+++ b/example/home/mutations.py
@@ -1,6 +1,10 @@
 import graphene
 from home.models import AuthorPage
-from wagtail.core.models import Page
+
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 
 from grapple.types.pages import PageInterface
 

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -11,8 +11,13 @@ from django.test.client import RequestFactory
 from django.utils.safestring import SafeText
 from home.blocks import CarouselBlock, ImageGalleryImages
 from home.factories import BlogPageFactory, TextWithCallableBlockFactory
-from wagtail.core.blocks import StreamValue
-from wagtail.core.rich_text import RichText
+
+try:
+    from wagtail.blocks import StreamValue
+    from wagtail.rich_text import RichText
+except ImportError:
+    from wagtail.core.blocks import StreamValue
+    from wagtail.core.rich_text import RichText
 from wagtail.embeds.blocks import EmbedValue
 
 from example.tests.test_grapple import BaseGrappleTest

--- a/example/home/test/test_general.py
+++ b/example/home/test/test_general.py
@@ -407,7 +407,7 @@ class TestUtils(BaseGrappleTest):
 
         results = self.client.execute(
             query,
-            variables={"term": "t", "limit": 1},
+            variables={"term": "Test", "limit": 1},
         )
         pages = results["data"]["pages"]
         self.assertEqual(len(pages), 1)
@@ -415,7 +415,7 @@ class TestUtils(BaseGrappleTest):
 
         results = self.client.execute(
             query,
-            variables={"term": "t", "limit": 2, "offset": 1},
+            variables={"term": "Test", "limit": 2, "offset": 1},
         )
         pages = results["data"]["pages"]
         self.assertEqual(len(pages), 2)
@@ -436,7 +436,7 @@ class TestUtils(BaseGrappleTest):
         with override_settings(GRAPPLE={"PAGE_SIZE": 10, "MAX_PAGE_SIZE": 1}):
             results = self.client.execute(
                 query,
-                variables={"term": "t", "limit": 2},
+                variables={"term": "Test", "limit": 2},
             )
 
         pages = results["data"]["pages"]
@@ -447,7 +447,7 @@ class TestUtils(BaseGrappleTest):
         with override_settings(GRAPPLE={"PAGE_SIZE": 1, "MAX_PAGE_SIZE": 5}):
             results = self.client.execute(
                 query,
-                variables={"term": "t", "limit": 2},
+                variables={"term": "Test", "limit": 2},
             )
 
         pages = results["data"]["pages"]

--- a/example/home/wagtail_hooks.py
+++ b/example/home/wagtail_hooks.py
@@ -1,4 +1,7 @@
-from wagtail.core import hooks
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
 
 from .mutations import Mutations
 from .subscriptions import Subscription

--- a/example/search/views.py
+++ b/example/search/views.py
@@ -1,6 +1,10 @@
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import render
-from wagtail.core.models import Page
+
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 from wagtail.search.models import Query
 
 

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -8,9 +8,15 @@ from django.db import models
 from django.template.loader import render_to_string
 from graphene_django.types import DjangoObjectType
 from wagtail.contrib.settings.models import BaseSetting
-from wagtail.core.blocks import StructValue, stream_block
-from wagtail.core.models import Page as WagtailPage
-from wagtail.core.rich_text import RichText, expand_db_html
+
+try:
+    from wagtail.blocks import StructValue, stream_block
+    from wagtail.models import Page as WagtailPage
+    from wagtail.rich_text import RichText, expand_db_html
+except ImportError:
+    from wagtail.core.blocks import StructValue, stream_block
+    from wagtail.core.models import Page as WagtailPage
+    from wagtail.core.rich_text import RichText, expand_db_html
 from wagtail.documents.models import AbstractDocument
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.models import AbstractImage, AbstractRendition

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -305,7 +305,7 @@ def register_singular_query_field(
                     qs = cls.objects
                     if "order" in kwargs:
                         qs = qs.order_by(
-                            *map(lambda x: x.strip(), kwargs.pop("order").split(","))
+                            *(x.strip() for x in kwargs.pop("order").split(","))
                         )
 
                     # If is a Page then only query live/public pages.

--- a/grapple/schema.py
+++ b/grapple/schema.py
@@ -1,6 +1,10 @@
 import graphene
 from graphql.validation.rules import NoUnusedFragments, specified_rules
-from wagtail.core import hooks
+
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
 
 from .registry import registry
 from .settings import grapple_settings

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -1,6 +1,10 @@
 import graphene
 from graphene_django.types import DjangoObjectType
-from wagtail.core.models import Collection
+
+try:
+    from wagtail.models import Collection
+except ImportError:
+    from wagtail.core.models import Collection
 
 from ..registry import registry
 from ..utils import resolve_queryset

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -4,8 +4,13 @@ from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 from graphene_django.types import DjangoObjectType
 from graphql.error import GraphQLLocatedError
-from wagtail.core.models import Page as WagtailPage
-from wagtail.core.models import Site
+
+try:
+    from wagtail.models import Page as WagtailPage
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Page as WagtailPage
+    from wagtail.core.models import Site
 from wagtail_headless_preview.signals import preview_update
 
 from ..registry import registry
@@ -75,7 +80,7 @@ class PageInterface(graphene.Interface):
     def resolve_parent(self, info, **kwargs):
         """
         Resolves the parent node of current page node.
-        Docs: https://docs.wagtail.io/en/stable/reference/pages/model_reference.html#wagtail.core.models.Page.get_parent
+        Docs: https://docs.wagtail.io/en/stable/reference/pages/model_reference.html#wagtail.models.Page.get_parent
         """
         try:
             return self.get_parent().specific
@@ -94,7 +99,7 @@ class PageInterface(graphene.Interface):
     def resolve_siblings(self, info, **kwargs):
         """
         Resolves a list of sibling nodes to this page.
-        Docs: https://docs.wagtail.io/en/stable/reference/pages/queryset_reference.html?highlight=get_siblings#wagtail.core.query.PageQuerySet.sibling_of
+        Docs: https://docs.wagtail.io/en/stable/reference/pages/queryset_reference.html?highlight=get_siblings#wagtail.query.PageQuerySet.sibling_of
         """
         return resolve_queryset(
             self.get_siblings().exclude(pk=self.pk).live().public().specific(),

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -2,8 +2,13 @@ import graphene
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 from graphene_django.types import DjangoObjectType
-from wagtail.core.models import Page as WagtailPage
-from wagtail.core.models import Site
+
+try:
+    from wagtail.models import Page as WagtailPage
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Page as WagtailPage
+    from wagtail.core.models import Site
 
 from ..utils import resolve_queryset
 from .pages import PageInterface, get_specific_page

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -10,9 +10,15 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from graphene.types import Scalar
 from graphene_django.converter import convert_django_field
-from wagtail.core import blocks
-from wagtail.core.fields import StreamField
-from wagtail.core.rich_text import expand_db_html
+
+try:
+    from wagtail import blocks
+    from wagtail.fields import StreamField
+    from wagtail.rich_text import expand_db_html
+except ImportError:
+    from wagtail.core import blocks
+    from wagtail.core.fields import StreamField
+    from wagtail.core.rich_text import expand_db_html
 from wagtail.embeds.blocks import EmbedValue
 from wagtail.embeds.embeds import get_embed
 from wagtail.embeds.exceptions import EmbedException
@@ -127,14 +133,11 @@ def serialize_struct_obj(obj):
         for field in obj:
             value = obj[field]
             if hasattr(value, "raw_data"):
-                rtn_obj[field] = list(
-                    map(lambda data: serialize_struct_obj(data.value), value[0])
-                )
+                rtn_obj[field] = [serialize_struct_obj(data.value) for data in value[0]]
             elif hasattr(obj, "stream_data"):
-                map(
-                    lambda data: serialize_struct_obj(data["value"]),
-                    value.stream_data,
-                )
+                rtn_obj[field] = [
+                    serialize_struct_obj(data["value"]) for data in value.stream_data
+                ]
             elif hasattr(value, "value"):
                 rtn_obj[field] = value.value
             elif hasattr(value, "src"):

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -77,7 +77,7 @@ def resolve_queryset(
         return _sliced_queryset(qs, limit, offset)
 
     if order is not None:
-        qs = qs.order_by(*map(lambda x: x.strip(), order.split(",")))
+        qs = qs.order_by(*(x.strip() for x in order.split(",")))
 
     if collection is not None:
         try:
@@ -167,7 +167,7 @@ def resolve_paginated_queryset(
         return get_paginated_result(results, page, per_page)
 
     if order is not None:
-        qs = qs.order_by(*map(lambda x: x.strip(), order.split(",")))
+        qs = qs.order_by(*(x.strip() for x in order.split(",")))
 
     return get_paginated_result(qs, page, per_page)
 

--- a/grapple/wagtail_hooks.py
+++ b/grapple/wagtail_hooks.py
@@ -1,5 +1,9 @@
 from graphene import ObjectType
-from wagtail.core import hooks
+
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
 
 from .registry import registry
 from .types.collections import CollectionsQuery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=3.0,<4.0
-wagtail>=2.14,<4.0
+wagtail>=2.15,<4.0
 wagtailmedia
 graphql-core>=2.2.1,<3
 graphene-django>=2.7.1, <2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=3.0,<4.0
-wagtail>=2.14,<2.17
+wagtail>=2.14,<4.0
 wagtailmedia
 graphql-core>=2.2.1,<3
 graphene-django>=2.7.1, <2.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
   Programming Language :: Python :: 3.9
   Framework :: Wagtail
   Framework :: Wagtail :: 2
+  Framework :: Wagtail :: 3
   Topic :: Scientific/Engineering
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -40,7 +41,7 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=3.0,<4.0
-    wagtail>=2.14, <2.17
+    wagtail>=2.14, <3.1
     graphene-django>=2.7.1, <2.14.0
     graphql-core>=2.2.1, <3
     wagtail-headless-preview

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=3.0,<4.0
-    wagtail>=2.14, <3.1
+    wagtail>=2.14, <4.0
     graphene-django>=2.7.1, <2.14.0
     graphql-core>=2.2.1, <3
     wagtail-headless-preview

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=3.0,<4.0
-    wagtail>=2.14, <4.0
+    wagtail>=2.15, <4.0
     graphene-django>=2.7.1, <2.14.0
     graphql-core>=2.2.1, <3
     wagtail-headless-preview


### PR DESCRIPTION
This PR brings wagtail 3 support to Grapple.

Questions / comments :
- [ ] I had failing tests following the upgrade, because of the search query `"searchQuery": "t"` in the tests, that returned no pages. Could it be because of changes in Wagtail ? I updated the query to search for `"searchQuery": "Test"` and it works properly. 
- [ ] I did not update wagtail.core paths in migrations, should we update these as well ? 
- [ ] Flake8 complained about C417 error, I fixed these in this PR 