### PR TITLE
Add urlPath to page field under SiteObjectType

### DIFF
--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -245,7 +245,7 @@ the ``sites`` or ``site`` field on the root query type. Available fields for the
     hostname: String
     isDefaultSite: Boolean
     rootPage: PageInterface
-    page(id: Int, slug: String, urlPath: String, contentType: String, token: String, inSite: Boolean): PageInterface
+    page(id: Int, slug: String, urlPath: String, contentType: String, token: String): PageInterface
     pages(limit: PositiveInt, offset: PositiveInt, order: String, searchQuery: String, id: ID): [PageInterface]
 
 

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -416,7 +416,7 @@ class BlogTest(BaseGrappleTest):
             "height": 113,
             "html": '<iframe width="200" height="113" src="https://www.youtube.com/embed/_U79Wc965vw?feature=oembed" '
             'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; '
-            'picture-in-picture" allowfullscreen></iframe>',
+            'picture-in-picture" allowfullscreen title="Wagtail Space 2018"></iframe>',
         }
         for block in body:
             if block["blockType"] == "VideoBlock":

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -29,6 +29,7 @@ class SiteObjectType(DjangoObjectType):
         PageInterface,
         id=graphene.Int(),
         slug=graphene.String(),
+        url_path=graphene.String(),
         token=graphene.String(),
         content_type=graphene.String(),
     )
@@ -54,6 +55,7 @@ class SiteObjectType(DjangoObjectType):
         return get_specific_page(
             id=kwargs.get("id"),
             slug=kwargs.get("slug"),
+            url_path=kwargs.get("url_path"),
             token=kwargs.get("token"),
             content_type=kwargs.get("content_type"),
             site=self,


### PR DESCRIPTION
Currently the urlPath is missing from the page field for `SiteObjectType`. 
This results in the error `"message": "Unknown argument \"urlPath\" on field \"page\" of type \"SiteObjectType\"."`, and limits functionality specified in the documentation.

This can be seen via graphiql on the example site 
Example: 
<img width="345" alt="Screenshot 2022-06-16 at 10 35 07" src="https://user-images.githubusercontent.com/35934884/174283883-48665120-8945-4573-b00d-3b9eca6804b2.png">


This PR also removes references within the documentation for the `inSite` field for this type.