### PR TITLE
Don't import wagtailmedia models if it's not in INSTALLED_APPS

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -4,6 +4,7 @@ from types import MethodType
 from typing import Any, Dict, Type
 
 import graphene
+from django.apps import apps
 from django.db import models
 from django.template.loader import render_to_string
 from graphene_django.types import DjangoObjectType
@@ -30,13 +31,14 @@ from .types.images import ImageObjectType
 from .types.pages import Page, PageInterface
 from .types.streamfield import generate_streamfield_union
 
-try:
+if apps.is_installed("wagtailmedia"):
     from wagtailmedia.models import AbstractMedia
 
     from .types.media import MediaObjectType
 
     has_wagtail_media = True
-except ModuleNotFoundError:
+
+else:
     # TODO: find a better way to have this as an optional dependency
     class AbstractMedia:
         def __init__(self):


### PR DESCRIPTION
If you have ``wagtailmedia`` installed with pip, but not in ``INSTALLED_APPS``, Django will raise an error on startup:

```
Traceback (most recent call last):
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/core/management/commands/runserver.py", line 110, in inner_run
    autoreload.raise_last_exception()
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/core/management/__init__.py", line 375, in execute
    autoreload.check_errors(django.setup)()
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/apps/registry.py", line 122, in populate
    app_config.ready()
  File "/workspace/gitpod-wagtail-develop/wagtail-grapple/grapple/apps.py", line 12, in ready
    from .actions import import_apps, load_type_fields
  File "/workspace/gitpod-wagtail-develop/wagtail-grapple/grapple/actions.py", line 42, in <module>
    from wagtailmedia.models import AbstractMedia
  File "/workspace/.pip-modules/lib/python3.8/site-packages/wagtailmedia/models.py", line 157, in <module>
    class Media(AbstractMedia):
  File "/workspace/.pip-modules/lib/python3.8/site-packages/django/db/models/base.py", line 113, in __new__
    raise RuntimeError(
RuntimeError: Model class wagtailmedia.models.Media doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

This PR adds a check to see if ``wagtailmedia`` is in ``INSTALLED_APPS`` before trying to import its models.