### PR TITLE
fix: WAGTAIL_ADMIN_BASEURL warning in tests

### DIFF
--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -163,7 +163,11 @@ WAGTAILDOCS_SERVE_METHOD = "serve_view"
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
+# BASE_URL is removed as of WAGTAIL 3.0, remove once WAGTAIL 2.0 is no longer supported
 BASE_URL = "http://localhost:8000"
+# as of Wagtail 3.0 BASE_URL was renamed to WAGTAILADMIN_BASE_URL, both are provided here for compatibility
+# when testing with Wagtail 2.0
+WAGTAILADMIN_BASE_URL = "http://localhost:8000"
 
 CORS_ORIGIN_ALLOW_ALL = True
 


### PR DESCRIPTION
When running the test in the example the following warning is emitted.

```
WARNINGS:
?: (wagtailadmin.W003) The WAGTAILADMIN_BASE_URL setting is not defined
        HINT: This should be the base URL used to access the Wagtail admin site. Without this, URLs in notification emails will not display correctly.
```

applies to #234 