### PR TITLE
fix: cannot access the file because it is being used

### DIFF
--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -706,10 +706,9 @@ class DocumentsTest(BaseGrappleTest):
 
         self.assertEqual(example_doc.id, 1)
         self.assertEqual(example_doc.title, "Example File")
-
-        example_doc.file.seek(0)
-
-        self.assertEqual(example_doc.file.readline(), b"Hello world!")
+        with example_doc.open_file() as file:
+            file.seek(0)
+            self.assertEqual(file.readline(), b"Hello world!")
 
         self.assertNotEqual(example_doc.file_hash, "")
         self.assertNotEqual(example_doc.file_size, None)


### PR DESCRIPTION
Windows will prevent a file from being deleted if a process
has an open handle on the file. The model needs to be deleted
to remove it's reference and then the file needs to be closed
before removing.

Fixes #244