### PR TITLE
fix: Unlink of example/db.sqlite3 failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Run Tests
         run: |
           cd example
-          rm db.sqlite3
           python manage.py migrate
           python manage.py test
 
@@ -79,7 +78,6 @@ jobs:
       - name: Run Tests
         run: |
           cd example
-          rm db.sqlite3
           python manage.py migrate
           python manage.py test
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 local_settings.py
 media
+*.sqlite3
 
 ### Django.Python Stack ###
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Contributions are what make the open source community such an amazing place to b
 
 -   In the python environment of your choice, navigate to `/example`
 -   Run `pip install -r requirements.txt`
--   Delete the `db.sqlite3` file and run `./manage.py migrate`
+-   Run `./manage.py migrate`
 -   Run server `./manage.py runserver`
 -   Run tests `./manage.py test`
 

--- a/example/db.sqlite3
+++ b/example/db.sqlite3
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:207019db3d1af7a6d919b623e5643c0f8a9db738a2bda53df33844b9490cbe66
-size 1134592


### PR DESCRIPTION
The second instruction for developers is to remove this file. It creates
issues when switching branches during development with the server
running. This commit removes it. If standard test data is needed, the
project should use factories or fixtures instead of a backed in DB for
better cross platform compatibilty and consistency.

Fixes #246