### PR TITLE
fix: graphiql xss vulnerability

### DIFF
--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -9,7 +9,7 @@ from .settings import grapple_settings, has_channels
 def graphiql(request):
     graphiql_settings = {
         "REACT_VERSION": "16.14.0",
-        "GRAPHIQL_VERSION": "1.4.2",
+        "GRAPHIQL_VERSION": "1.11.2",
         "endpointURL": reverse("grapple_graphql"),
         "supports_subscriptions": has_channels,
     }


### PR DESCRIPTION
upgrade to graphiql >= 1.4.7

see: https://github.com/graphql/graphiql/blob/main/docs/security/2021-introspection-schema-xss.md

also applies to #104 