### PR TITLE
Support specifying format in image srcSet query

### DIFF
--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -122,7 +122,10 @@ need for Gatsby Image features to work (see Handy Fragments page for more info):
     fileHash: String!
     renditions: [ImageRenditionObjectType]
     src: String
-    srcSet(sizes: [Int]): String
+    srcSet(
+        sizes: [Int]
+        format: String
+    ): String
     rendition(
         max: String
         min: String

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -679,6 +679,54 @@ class ImagesTest(BaseGrappleTest):
         self.assertNotIn("width-100", executed["data"]["image"]["srcSet"])
         self.assertIn("width-200", executed["data"]["image"]["srcSet"])
 
+    def test_src_set_with_format(self):
+        query = """
+        {
+            image(id: 1) {
+                srcSet(sizes: [100, 300], format: "webp")
+            }
+        }
+        """
+        executed = self.client.execute(query)
+        self.assertIn("width-100.format-webp.webp", executed["data"]["image"]["srcSet"])
+        self.assertIn("width-300.format-webp.webp", executed["data"]["image"]["srcSet"])
+
+    def test_src_set_invalid_format(self):
+        query = """
+        {
+            image(id: 1) {
+                srcSet(sizes: [100, 300], format: "foobar")
+            }
+        }
+        """
+        executed = self.client.execute(query)
+        self.assertEqual(len(executed["errors"]), 1)
+        self.assertIn("Format must be either 'jpeg'", executed["errors"][0]["message"])
+
+    @override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": ["width-200"]})
+    def test_src_set_disallowed_filter(self):
+        query = """
+        {
+            image(id: 1) {
+                srcSet(sizes: [200], format: "webp")
+            }
+        }
+        """
+        executed = self.client.execute(query)
+        self.assertEqual("", executed["data"]["image"]["srcSet"])
+
+    @override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": ["width-200|format-webp"]})
+    def test_src_set_allowed_filter(self):
+        query = """
+        {
+            image(id: 1) {
+                srcSet(sizes: [200], format: "webp")
+            }
+        }
+        """
+        executed = self.client.execute(query)
+        self.assertIn("width-200.format-webp.webp", executed["data"]["image"]["srcSet"])
+
     def test_rendition_allowed_method(self):
         self.assertTrue(rendition_allowed("width-100"))
         with override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": ["width-200"]}):

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -94,7 +94,9 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
         jpegquality=graphene.Int(),
         webpquality=graphene.Int(),
     )
-    src_set = graphene.String(sizes=graphene.List(graphene.Int))
+    src_set = graphene.String(
+        sizes=graphene.List(graphene.Int), format=graphene.String()
+    )
 
     class Meta:
         model = WagtailImage
@@ -123,15 +125,19 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
                 image=self,
             )
 
-    def resolve_src_set(self, info, sizes, **kwargs):
+    def resolve_src_set(self, info, sizes, format=None, **kwargs):
         """
         Generate src set of renditions.
         """
+        filter_suffix = f"|format-{format}" if format else ""
+        format_kwarg = {"format": format} if format else {}
         if self.file.name is not None:
             rendition_list = [
-                ImageObjectType.resolve_rendition(self, info, width=width)
+                ImageObjectType.resolve_rendition(
+                    self, info, width=width, **format_kwarg
+                )
                 for width in sizes
-                if rendition_allowed(f"width-{width}")
+                if rendition_allowed(f"width-{width}{filter_suffix}")
             ]
 
             return ", ".join(


### PR DESCRIPTION
Closes #238 

Allows the format of renditions to be specified when performing an Image srcSet query