### PR TITLE
Multi site support

### DIFF
--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -264,6 +264,18 @@ class SitesTest(TestCase):
         self.site = wagtail_factories.SiteFactory(
             hostname="grapple.localhost", site_name="Grapple test site"
         )
+
+        self.site_different_hostname = wagtail_factories.SiteFactory(
+            hostname="different-hostname.localhost",
+            site_name="Grapple test site (different hostname)",
+        )
+
+        self.site_different_hostname_different_port = wagtail_factories.SiteFactory(
+            hostname="different-hostname.localhost",
+            port=8000,
+            site_name="Grapple test site (different hostname/port)",
+        )
+
         self.client = Client(SCHEMA)
         self.home = HomePage.objects.first()
 
@@ -311,11 +323,62 @@ class SitesTest(TestCase):
         self.assertEquals(type(executed["data"]["site"]), dict_type)
         self.assertEquals(type(executed["data"]["site"]["pages"]), list)
 
+        self.assertEquals(executed["data"]["site"]["siteName"], "Grapple test site")
+
         pages = Page.objects.in_site(self.site)
 
         self.assertEquals(len(executed["data"]["site"]["pages"]), pages.count())
         self.assertNotEqual(
             len(executed["data"]["site"]["pages"]), Page.objects.count()
+        )
+
+    def test_site_errors_when_multiple_sites_match_hostname_and_port_unspecified(self):
+        query = """
+        query($hostname: String) {
+            site(hostname: $hostname) {
+                siteName
+            }
+        }
+        """
+
+        executed = self.client.execute(
+            query, variables={"hostname": self.site_different_hostname.hostname}
+        )
+
+        self.assertEquals(
+            executed,
+            {
+                "errors": [
+                    {
+                        "message": "Your 'hostname' filter value of "
+                        "'different-hostname.localhost' returned multiple "
+                        "sites. Try adding a port number (for example: "
+                        "'different-hostname.localhost:80').",
+                        "locations": [{"line": 3, "column": 13}],
+                        "path": ["site"],
+                    }
+                ],
+                "data": {"site": None},
+            },
+        )
+
+    def test_site_with_different_port(self):
+        query = """
+        query($hostname: String) {
+            site(hostname: $hostname) {
+                siteName
+            }
+        }
+        """
+
+        executed = self.client.execute(
+            query,
+            variables={"hostname": self.site_different_hostname.hostname + ":8000"},
+        )
+
+        self.assertEquals(
+            executed["data"]["site"]["siteName"],
+            "Grapple test site (different hostname/port)",
         )
 
     def test_site_pages_content_type_filter(self):
@@ -445,6 +508,11 @@ class SitesTest(TestCase):
         self.assertEquals(data["title"], blog.title)
 
     def test_site_page_url_path_filter(self):
+        # These additional sites prevent the .relative_url() call below from returning a relative URL
+        # They're not needed for this particular test
+        self.site_different_hostname.delete()
+        self.site_different_hostname_different_port.delete()
+
         query = """
         query($hostname: String $urlPath: String) {
             site(hostname: $hostname) {

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -4,7 +4,9 @@ from django.db.models import Q
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 from graphene_django.types import DjangoObjectType
-from graphql.error import GraphQLLocatedError
+from graphql.error import GraphQLError, GraphQLLocatedError
+
+from ..utils import resolve_site
 
 try:
     from wagtail.models import Page as WagtailPage
@@ -229,6 +231,27 @@ def PagesQuery():
     # Add base type to registry
     registry.pages[type(WagtailPage)] = Page
 
+    def get_site_filter(info, **kwargs):
+        site_hostname = kwargs.pop("site", None)
+        in_current_site = kwargs.get("in_site", False)
+
+        if site_hostname is not None and in_current_site:
+            raise GraphQLError(
+                "The 'site' and 'in_site' filters cannot be used at the same time."
+            )
+
+        if site_hostname is not None:
+            try:
+                return resolve_site(site_hostname)
+            except Site.MultipleObjectsReturned:
+                raise GraphQLError(
+                    "Your 'site' filter value of '{}' returned multiple sites. Try adding a port number (for example: '{}:80').".format(
+                        site_hostname, site_hostname
+                    )
+                )
+        elif in_current_site:
+            return Site.find_for_request(info.context)
+
     class Mixin:
         pages = QuerySetList(
             graphene.NonNull(lambda: PageInterface),
@@ -243,6 +266,7 @@ def PagesQuery():
                 description=_("Filter to pages in the current site only."),
                 default_value=False,
             ),
+            site=graphene.String(),
             enable_search=True,
             required=True,
         )
@@ -274,6 +298,7 @@ def PagesQuery():
                 description=_("Filter to pages in the current site only."),
                 default_value=False,
             ),
+            site=graphene.String(),
         )
 
         # Return all pages in site, ideally specific.
@@ -282,8 +307,8 @@ def PagesQuery():
                 WagtailPage.objects.live().public().filter(depth__gt=1).specific()
             )  # no need to the root page
 
-            if kwargs.get("in_site", False):
-                site = Site.find_for_request(info.context)
+            site = get_site_filter(info, **kwargs)
+            if site is not None:
                 pages = pages.in_site(site)
 
             content_type = kwargs.pop("content_type", None)
@@ -307,9 +332,7 @@ def PagesQuery():
                 url_path=kwargs.get("url_path"),
                 token=kwargs.get("token"),
                 content_type=kwargs.get("content_type"),
-                site=Site.find_for_request(info.context)
-                if kwargs.get("in_site", False)
-                else None,
+                site=get_site_filter(info, **kwargs),
             )
 
     return Mixin

--- a/grapple/types/settings.py
+++ b/grapple/types/settings.py
@@ -1,4 +1,10 @@
 import graphene
+from graphql.error import GraphQLError
+
+try:
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Site
 
 from ..registry import registry
 from ..utils import resolve_site
@@ -35,7 +41,18 @@ def SettingsQuery():
                 # Site filter
                 # Only applies to settings that inherit from BaseSiteSetting
                 site_hostname = kwargs.pop("site", None)
-                site = resolve_site(site_hostname) if site_hostname else None
+
+                if site_hostname is not None:
+                    try:
+                        site = resolve_site(site_hostname)
+                    except Site.MultipleObjectsReturned:
+                        raise GraphQLError(
+                            "Your 'site' filter value of '{}' returned multiple sites. Try adding a port number (for example: '{}:80').".format(
+                                site_hostname, site_hostname
+                            )
+                        )
+                else:
+                    site = None
 
                 name = kwargs.get("name")
                 for setting in registry.settings:
@@ -53,7 +70,18 @@ def SettingsQuery():
                 # Site filter
                 # Only applies to settings that inherit from BaseSiteSetting
                 site_hostname = kwargs.pop("site", None)
-                site = resolve_site(site_hostname) if site_hostname else None
+
+                if site_hostname is not None:
+                    try:
+                        site = resolve_site(site_hostname)
+                    except Site.MultipleObjectsReturned:
+                        raise GraphQLError(
+                            "Your 'site' filter value of '{}' returned multiple sites. Try adding a port number (for example: '{}:80').".format(
+                                site_hostname, site_hostname
+                            )
+                        )
+                else:
+                    site = None
 
                 name = kwargs.get("name")
                 settings_objects = []

--- a/grapple/types/settings.py
+++ b/grapple/types/settings.py
@@ -1,37 +1,13 @@
 import graphene
-from graphql.error import GraphQLError
-from wagtail.core.models import Site
 
 from ..registry import registry
+from ..utils import resolve_site
 
 try:
     from wagtail.contrib.settings.models import BaseSiteSetting
 except ImportError:
     # Wagtail < 4.0
     from wagtail.contrib.settings.models import BaseSetting as BaseSiteSetting
-
-
-def resolve_site(hostname):
-    # Optionally allow querying by port
-    if ":" in hostname:
-        (hostname, port) = hostname.split(":", 1)
-        query = {
-            "hostname": hostname,
-            "port": port,
-        }
-    else:
-        query = {
-            "hostname": hostname,
-        }
-
-    try:
-        return Site.objects.get(**query)
-    except Site.MultipleObjectsReturned:
-        raise GraphQLError(
-            "Your 'site' filter value of '{}' returned multiple sites. Try adding a port number (for example: '{}:80').".format(
-                hostname, hostname
-            )
-        )
 
 
 def SettingsQuery():

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -2,6 +2,7 @@ import graphene
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 from graphene_django.types import DjangoObjectType
+from graphql.error import GraphQLError
 
 try:
     from wagtail.models import Page as WagtailPage
@@ -10,7 +11,7 @@ except ImportError:
     from wagtail.core.models import Page as WagtailPage
     from wagtail.core.models import Site
 
-from ..utils import resolve_queryset
+from ..utils import resolve_queryset, resolve_site
 from .pages import PageInterface, get_specific_page
 from .structures import QuerySetList
 
@@ -82,12 +83,16 @@ def SitesQuery():
         def resolve_site(self, info, **kwargs):
             id, hostname = kwargs.get("id"), kwargs.get("hostname")
 
-            try:
-                if id:
-                    return Site.objects.get(pk=id)
-                elif hostname:
-                    return Site.objects.get(hostname=hostname)
-            except BaseException:
-                return None
+            if id:
+                return Site.objects.filter(pk=id)
+            elif hostname:
+                try:
+                    return resolve_site(hostname)
+                except Site.MultipleObjectsReturned:
+                    raise GraphQLError(
+                        "Your 'hostname' filter value of '{}' returned multiple sites. Try adding a port number (for example: '{}:80').".format(
+                            hostname, hostname
+                        )
+                    )
 
     return Mixin

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -3,7 +3,6 @@ import os
 
 from django.conf import settings
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from graphql.error import GraphQLError
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 from wagtail.search.models import Query
@@ -32,7 +31,7 @@ def resolve_site(hostname):
 
     May raise one of the following exceptions:
      - Site.DoesNotExist: If the site is not found
-     - GraphQLError: If multiple sites are found for a given hostname
+     - Site.MultipleObjectsReturned: If multiple sites are found for a given hostname
 
     :param hostname: The hostname of the site to look up
     :type hostname: str
@@ -49,14 +48,7 @@ def resolve_site(hostname):
             "hostname": hostname,
         }
 
-    try:
-        return Site.objects.get(**query)
-    except Site.MultipleObjectsReturned:
-        raise GraphQLError(
-            "Your 'site' filter value of '{}' returned multiple sites. Try adding a port number (for example: '{}:80').".format(
-                hostname, hostname
-            )
-        )
+    return Site.objects.get(**query)
 
 
 def _sliced_queryset(qs, limit=None, offset=None):


### PR DESCRIPTION
Headless sites usually wouldn't be hosting the API on the same hostname as the frontend. It may also be hosting multiple frontend domains off the same API domain.

This PR enables the frontend to filter pages, and sites by a particular site hostname.