### PR TITLE
Capture FieldDoesNotExist errors when getting the type of a model instance's field

### DIFF
--- a/example/home/models.py
+++ b/example/home/models.py
@@ -50,6 +50,7 @@ from grapple.middleware import IsAnonymousMiddleware
 from grapple.models import (
     GraphQLCollection,
     GraphQLDocument,
+    GraphQLField,
     GraphQLForeignKey,
     GraphQLImage,
     GraphQLMedia,
@@ -58,7 +59,6 @@ from grapple.models import (
     GraphQLStreamfield,
     GraphQLString,
     GraphQLTag,
-    GraphQLField
 )
 from grapple.utils import resolve_paginated_queryset
 
@@ -157,7 +157,10 @@ class BlogPage(HeadlessPreviewMixin, Page):
 
     @cached_property
     def custom_property(self):
-        return {"path": self.url, "author": self.author.name if self.author else "Unknown"}
+        return {
+            "path": self.url,
+            "author": self.author.name if self.author else "Unknown",
+        }
 
     graphql_fields = [
         GraphQLString("date", required=True),

--- a/example/home/models.py
+++ b/example/home/models.py
@@ -1,6 +1,7 @@
 import graphene
 from django.conf import settings
 from django.db import models
+from django.utils.functional import cached_property
 from home.blocks import StreamFieldBlock
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
@@ -57,6 +58,7 @@ from grapple.models import (
     GraphQLStreamfield,
     GraphQLString,
     GraphQLTag,
+    GraphQLField
 )
 from grapple.utils import resolve_paginated_queryset
 
@@ -153,9 +155,18 @@ class BlogPage(HeadlessPreviewMixin, Page):
     def paginated_authors(self, info, **kwargs):
         return resolve_paginated_queryset(self.authors, info, **kwargs)
 
+    @cached_property
+    def custom_property(self):
+        return {"path": self.url, "author": self.author.name if self.author else "Unknown"}
+
     graphql_fields = [
         GraphQLString("date", required=True),
         GraphQLString("summary"),
+        GraphQLField(
+            field_name="custom_property",
+            field_type=graphene.JSONString,
+            required=False,
+        ),
         GraphQLStreamfield("body"),
         GraphQLTag("tags"),
         GraphQLCollection(

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -949,5 +949,5 @@ class BlogTest(BaseGrappleTest):
         # Check custom property.
         self.assertEquals(
             json.loads(executed["data"]["page"]["customProperty"]),
-            self.blog_page.custom_property
+            self.blog_page.custom_property,
         )

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -933,3 +933,21 @@ class BlogTest(BaseGrappleTest):
 
                 # Ensure TextWithCallableBlock.get_field_method called.
                 self.assertIn("text-with-callable", result)
+
+    def test_custom_property(self):
+        query = """
+        query($id: Int) {
+            page(id: $id) {
+                ... on BlogPage {
+                    customProperty
+                }
+            }
+        }
+        """
+        executed = self.client.execute(query, variables={"id": self.blog_page.id})
+
+        # Check custom property.
+        self.assertEquals(
+            json.loads(executed["data"]["page"]["customProperty"]),
+            self.blog_page.custom_property
+        )

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, Type, Union
 
 import graphene
 from django.apps import apps
-from django.db import models
 from django.core.exceptions import FieldDoesNotExist
+from django.db import models
 from django.template.loader import render_to_string
 from graphene_django.types import DjangoObjectType
 

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Type, Union
 import graphene
 from django.apps import apps
 from django.db import models
+from django.core.exceptions import FieldDoesNotExist
 from django.template.loader import render_to_string
 from graphene_django.types import DjangoObjectType
 
@@ -230,18 +231,22 @@ def model_resolver(field):
             return cls_field(info, **kwargs)
 
         # Expand HTML if the value's field is richtext
-        if hasattr(instance._meta, "get_field"):
-            field_model = instance._meta.get_field(field.field_name)
-        else:
-            field_model = instance._meta.fields[field.field_name]
+        try:
+            if hasattr(instance._meta, "get_field"):
+                field_model = instance._meta.get_field(field.field_name)
+            else:
+                field_model = instance._meta.fields[field.field_name]
+        except FieldDoesNotExist:
+            return cls_field
 
-        if (
-            type(field_model) is RichTextField
-            and grapple_settings.RICHTEXT_FORMAT == "html"
-        ):
-            return render_to_string(
-                "wagtailcore/richtext.html", {"html": expand_db_html(cls_field)}
-            )
+        else:
+            if (
+                type(field_model) is RichTextField
+                and grapple_settings.RICHTEXT_FORMAT == "html"
+            ):
+                return render_to_string(
+                    "wagtailcore/richtext.html", {"html": expand_db_html(cls_field)}
+                )
 
         # If none of those then just return field
         return cls_field


### PR DESCRIPTION
The goal of this PR is to avoid `FieldDoesNotExist` errors for GraphQL fields that aren't actual fields in the model.
I've added a failing test to exhibit the issue.