### PR TITLE
Fix returned ID for nested StructBlock in StreamBlock

### DIFF
--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -735,6 +735,27 @@ class BlogTest(BaseGrappleTest):
                 self.assertEquals(button["buttonText"], "Take me to the source")
                 self.assertEquals(button["buttonLink"], "https://wagtail.io/")
 
+    def test_nested_structvalue_block_id(self):
+        block_type = "CarouselBlock"
+        query_blocks = self.get_blocks_from_body(
+            block_type,
+            block_query="""
+                blocks {
+                    ...on ImageChooserBlock {
+                        id
+                    }
+                }
+            """,
+        )
+
+        blocks = query_blocks[0]["blocks"]
+
+        # Check that the id returned matches the original block's ID
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                for i, image_block in enumerate(block.value):
+                    self.assertEquals(blocks[i]["id"], image_block.id)
+
     def test_block_with_name(self):
         block_type = "BlockWithName"
         block_query = "name"

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -193,15 +193,14 @@ class StreamBlock(StructBlock):
         interfaces = (StreamFieldInterface,)
 
     def resolve_blocks(self, info, **kwargs):
-        stream_blocks = []
+        child_blocks = self.value.stream_block.child_blocks
 
-        for stream in self.value:
-            block_type = stream.block_type
-            value = stream.value
-            block = self.value.stream_block.child_blocks[block_type]
-            stream_blocks.append(StructBlockItem(block_type, block, value))
-
-        return stream_blocks
+        return [
+            StructBlockItem(
+                id=stream.id, block=child_blocks[stream.block_type], value=stream.value
+            )
+            for stream in self.value
+        ]
 
 
 class StreamFieldBlock(graphene.ObjectType):


### PR DESCRIPTION
Fixes #268.

The issue was with `StructBlockItem` being passed the wrong arguments.

_Note_: It'd be nice to start using the [`blocks_by_name`](https://docs.wagtail.org/en/latest/topics/streamfield.html#retrieving-blocks-by-name) method in tests where we retrieve a block by its name when Wagtail 4 support is added.