### PR TITLE
fix: blog embed test

### DIFF
--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -515,7 +515,7 @@ class BlogTest(BaseGrappleTest):
             "height": 113,
             "html": '<iframe width="200" height="113" src="https://www.youtube.com/embed/_U79Wc965vw?feature=oembed" '
             'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; '
-            'picture-in-picture" allowfullscreen title="Wagtail Space 2018"></iframe>',
+            'picture-in-picture; web-share" allowfullscreen title="Wagtail Space 2018"></iframe>',
         }
         for block in body:
             if block["blockType"] == "VideoBlock":


### PR DESCRIPTION
It seems upstream is now adding webshare if it's not present. Since out goal here is to implement grapple and not exhausitvely test the example site behavior, I've just updated our input to include web-share without regard for why this started breaking.