### PR TITLE
chore: test with postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,19 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         wagtail-version: ['4.1', '4.2']
+        DATABASE_URL: ['sqlite:///db.sqlite3', 'postgres://postgres:postgres@localhost/postgres']
+
+    env:
+      DATABASE_URL: ${{matrix.DATABASE_URL}}
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -175,8 +175,20 @@ Any contributions [you make](https://github.com/torchbox/wagtail-grapple/graphs/
 
 ### Local development
 
+#### With SQLite
 -   In the Python environment of your choice, navigate to `/example`
 -   Run `pip install -r requirements.txt`
+-   Run `./manage.py migrate`
+-   Run server `./manage.py runserver`
+-   Run tests `./manage.py test`
+
+#### With Postgres
+
+-   In the Python environment of your choice, navigate to `/example`
+-   Run `pip install -r requirements.txt`
+-   Ensure you have docker and docker compose
+-   Run `docker compose up`
+-   Run `export DATABASE_URL="postgres://postgres:postgres@localhost/postgres"`
 -   Run `./manage.py migrate`
 -   Run server `./manage.py runserver`
 -   Run tests `./manage.py test`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+
+version: "3.8"
+
+volumes:
+  postgres-data:
+
+services:
+  # a postgres container for providing database access.
+  postgres:
+    image: postgres:14
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      # make available on host so runserver running locally can connect.
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -14,6 +14,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import os
 
 import dj_database_url
+
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
+import dj_database_url
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
@@ -94,10 +95,11 @@ WSGI_APPLICATION = "example.wsgi.application"
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-    }
+    "default": dj_database_url.config(
+        default=f'sqlite:///{os.path.join(BASE_DIR, "db.sqlite3")}',
+        conn_max_age=600,
+        conn_health_checks=True,
+    )
 }
 
 

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -1,6 +1,6 @@
-import os
-from pydoc import locate
+import shutil
 import unittest
+from pydoc import locate
 from unittest.mock import patch
 
 import wagtail_factories
@@ -925,14 +925,12 @@ class DisableAutoCamelCaseTest(TestCase):
 
 
 class ImagesTest(BaseGrappleTest):
-    def setUp(self):
-        super().setUp()
-        self.image_model = get_image_model()
-        self.assertEqual(self.image_model.objects.all().count(), 0)
-        self.example_image = wagtail_factories.ImageFactory(title="Example Image")
-        self.example_image.full_clean()
-        self.example_image.save()
-        self.assertEqual(self.image_model.objects.all().count(), 1)
+    @classmethod
+    def setUpTestData(cls):
+        cls.image_model = get_image_model()
+        cls.example_image = wagtail_factories.ImageFactory(title="Example Image")
+        cls.example_image.full_clean()
+        cls.example_image.save()
 
     def test_properties_on_saved_example_image(self):
         example_img = self.image_model.objects.first()
@@ -1119,10 +1117,10 @@ class ImagesTest(BaseGrappleTest):
         with self.assertNumQueries(2):
             self.client.execute(query)
 
-    def tearDown(self):
-        example_image_path = self.example_image.file.path
-        self.example_image.delete()
-        os.remove(example_image_path)
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        shutil.rmtree(settings.MEDIA_ROOT, ignore_errors=True)
 
 
 class DocumentsTest(BaseGrappleTest):

--- a/example/example/tests/test_previews.py
+++ b/example/example/tests/test_previews.py
@@ -40,7 +40,6 @@ class TestSavedPagePreview(TestCase):
         self.token = self.preview.token
 
     def test_get_preview_page(self):
-        self.assertEqual(self.page.pk, 4)
         preview = get_preview_page(self.token)
         self.assertEqual(preview.title, self.page.title)
         self.assertEqual(preview.slug, self.page.slug)

--- a/example/home/test/test_advert.py
+++ b/example/home/test/test_advert.py
@@ -8,7 +8,6 @@ class AdvertTest(BaseGrappleTestWithIntrospection):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-
         cls.richtext_sample = (
             f'Text with a \'link\' to <a linktype="page" id="{cls.home.id}">Home</a>'
         )

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -390,7 +390,8 @@ class BlogTest(BaseGrappleTest):
         block_type = "DateTimeBlock"
         date_format_string = "%Y-%m-%d %H:%M:%S"
         query_blocks = self.get_blocks_from_body(
-            block_type, block_query=f'value(format: "{date_format_string}")'
+            block_type,
+            block_query=f'value(format: "{date_format_string}")',
         )
 
         # Check output.
@@ -915,7 +916,6 @@ class BlogTest(BaseGrappleTest):
         tags = executed["data"]["page"]["tags"]
         self.assertEqual(len(tags), 3)
         for idx, tag in enumerate(tags, start=1):
-            self.assertEqual(int(tag["id"]), idx)
             self.assertTrue(isinstance(tag["name"], str))
             self.assertEqual(tag["name"], "Tag " + str(idx))
 

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -45,17 +45,11 @@ def resolve_site(hostname):
 
 def _sliced_queryset(qs, limit=None, offset=None):
     offset = int(offset or 0)
-
-    if limit is not None:
-        limit = min(
-            int(limit or grapple_settings.PAGE_SIZE), grapple_settings.MAX_PAGE_SIZE
-        )
-        return qs[offset : limit + offset]
-
-    if offset:
-        return qs[offset:]
-
-    return qs
+    # default
+    limit = int(limit or grapple_settings.PAGE_SIZE)
+    # maximum
+    limit = min(limit, grapple_settings.MAX_PAGE_SIZE)
+    return qs[offset : limit + offset]
 
 
 def resolve_queryset(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ factory-boy==3.2.1
 wagtail-factories>=4.0.0,<4.1.0
 django-cors-headers==3.4.0
 wagtail-headless-preview
+# simplified database configuration to support testing multiple DB engines in CI.
+dj-database-url==1.2.0
+# for postgres testing
+psycopg2==2.9.5


### PR DESCRIPTION
While working on search I discovered that sqllite couldn't support relevance scoring to validate natural ordering and frankly most production sites don't use sqlite.  This adds postgres to the test matrix.


