### PR TITLE
Drop tests against Wagtail main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowfail }}
     strategy:
       fail-fast: false
       max-parallel: 4
-      allowfail: [false]
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
-        wagtail-version: ['4.1', '4.2', 'main']
-        include:
-          - python-version: '3.11'
-            wagtail-version: '4.1'
-          - python-version: '3.11'
-            wagtail-version: '4.2'
-          - python-version: '3.11'
-            wagtail-version: 'main'
-            allowfail: true
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        wagtail-version: ['4.1', '4.2']
 
     steps:
       - uses: actions/checkout@v3

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -173,7 +173,7 @@ GRAPHENE = {
     "MIDDLEWARE": ["grapple.middleware.GrappleMiddleware"],
 }
 
-GRAPPLE_EXPOSE_GRAPHIQL = True
+# GRAPPLE_EXPOSE_GRAPHIQL = True
 
 GRAPPLE = {
     "APPS": ["images", "home", "documents"],

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -536,7 +536,7 @@ class PageUrlPathTest(BaseGrappleTest):
         self.assertEqual(int(page_data["id"]), home_child.id)
 
         with patch(
-            f"{settings.WAGTAIL_CORE}.models.Site.find_for_request",
+            "wagtail.models.Site.find_for_request",
             return_value=another_site,
         ):
             page_data = self._query_by_path("/child/", in_site=True)

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -172,22 +172,26 @@ def ImagesQuery():
         )
         image_type = graphene.String(required=True)
 
-        @property
-        def _base_queryset(self):
-            return mdl.objects.filter(
-                collection__view_restrictions__isnull=True
-            ).prefetch_renditions()
-
         def resolve_image(self, info, id, **kwargs):
             """Returns an image given the id, if in a public collection"""
             try:
-                return self._base_queryset.get(pk=id)
+                return (
+                    mdl.objects.filter(collection__view_restrictions__isnull=True)
+                    .prefetch_renditions()
+                    .get(pk=id)
+                )
             except mdl.DoesNotExist:
                 return None
 
         def resolve_images(self, info, **kwargs):
             """Returns all images in a public collection"""
-            return resolve_queryset(self._base_queryset, info, **kwargs)
+            return resolve_queryset(
+                mdl.objects.filter(
+                    collection__view_restrictions__isnull=True
+                ).prefetch_renditions(),
+                info,
+                **kwargs,
+            )
 
         # Give name of the image type, used to generate mixins
         def resolve_image_type(self, info, **kwargs):

--- a/grapple/types/structures.py
+++ b/grapple/types/structures.py
@@ -15,7 +15,7 @@ class PositiveInt(Int):
 
     @staticmethod
     def parse_literal(ast, _variables=None):
-        return_value = super().parse_literal(ast, _variables=_variables)
+        return_value = Int.parse_literal(ast, _variables=_variables)
         if return_value is not None and return_value >= 0:
             return return_value
 


### PR DESCRIPTION
Missed the fact CI didn't run in #314
This drops the workarounds for allowing tests to fail on Wagtail main.

Will follow up in #289 