### PR TITLE
Pass arguments to callables for resolving StreamField block values

### DIFF
--- a/example/home/blocks.py
+++ b/example/home/blocks.py
@@ -139,8 +139,12 @@ class TextWithCallableBlock(blocks.StructBlock):
         # GraphQLField test attributes
         GraphQLField("field_property", graphene.String, source="get_field_property"),
         GraphQLField("field_method", graphene.String, source="get_field_method"),
-        (GraphQLString("field_method_with_extra_arg", source="get_field_method_with_extra_arg"),
-         lambda field_type: graphene.Field(field_type, extra_arg=graphene.String())),
+        (
+            GraphQLString(
+                "field_method_with_extra_arg", source="get_field_method_with_extra_arg"
+            ),
+            lambda field_type: graphene.Field(field_type, extra_arg=graphene.String()),
+        ),
     ]
 
     # GraphQLString test attributes

--- a/example/home/blocks.py
+++ b/example/home/blocks.py
@@ -139,6 +139,8 @@ class TextWithCallableBlock(blocks.StructBlock):
         # GraphQLField test attributes
         GraphQLField("field_property", graphene.String, source="get_field_property"),
         GraphQLField("field_method", graphene.String, source="get_field_method"),
+        (GraphQLString("field_method_with_extra_arg", source="get_field_method_with_extra_arg"),
+         lambda field_type: graphene.Field(field_type, extra_arg=graphene.String())),
     ]
 
     # GraphQLString test attributes
@@ -235,6 +237,13 @@ class TextWithCallableBlock(blocks.StructBlock):
         values: Dict[str, Any] = None,
     ) -> Optional[str]:
         return slugify(values.get("text")) if values else None
+
+    def get_field_method_with_extra_arg(
+        self,
+        values: Dict[str, Any] = None,
+        extra_arg: Optional[str] = None,
+    ) -> Optional[str]:
+        return extra_arg
 
 
 class StreamFieldBlock(blocks.StreamBlock):

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -1035,6 +1035,21 @@ class BlogTest(BaseGrappleTest):
                 # Ensure TextWithCallableBlock.get_field_method called.
                 self.assertIn("text-with-callable", result)
 
+    def test_graphqlfield_method_with_extra_arg_in_structblock(self):
+        block_type = "TextWithCallableBlock"
+        block_query_field = "fieldMethodWithExtraArg"
+        extra_arg = "hello"
+        block_query = f'{block_query_field}(extraArg: "{extra_arg}")'
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                # Ensure TextWithCallableBlock.field_method not called.
+                result = query_blocks[0][block_query_field]
+
+                # Ensure TextWithCallableBlock.get_field_method_with_extra_arg called with right argument.
+                self.assertIn(extra_arg, result)
+
     def test_custom_property(self):
         query = """
         query($id: Int) {

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -414,7 +414,7 @@ def custom_cls_resolver(*, cls, graphql_field):
         elif callable(getattr(cls, graphql_field.field_source)):
             return lambda self, instance, info, **kwargs: getattr(
                 klass, graphql_field.field_source
-            )(values=get_all_field_values(instance=instance, cls=cls))
+            )(values=get_all_field_values(instance=instance, cls=cls), **kwargs)
 
     # If the `field_name` is a property or method of the class: use it.
     if hasattr(graphql_field, "field_name") and hasattr(
@@ -427,7 +427,7 @@ def custom_cls_resolver(*, cls, graphql_field):
         elif callable(getattr(cls, graphql_field.field_name)):
             return lambda self, instance, info, **kwargs: getattr(
                 klass, graphql_field.field_name
-            )(values=get_all_field_values(instance=instance, cls=cls))
+            )(values=get_all_field_values(instance=instance, cls=cls), **kwargs)
 
     # No match found - fall back to the streamfield_resolver() later.
     return None
@@ -468,7 +468,7 @@ def build_streamfield_type(
 
             # Add support for `graphql_fields`
             methods["resolve_" + field.field_name] = (
-                custom_cls_resolver(cls=cls, graphql_field=item) or streamfield_resolver
+                custom_cls_resolver(cls=cls, graphql_field=field) or streamfield_resolver
             )
 
             # Add field to GQL type with correct field-type

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -468,7 +468,8 @@ def build_streamfield_type(
 
             # Add support for `graphql_fields`
             methods["resolve_" + field.field_name] = (
-                custom_cls_resolver(cls=cls, graphql_field=field) or streamfield_resolver
+                custom_cls_resolver(cls=cls, graphql_field=field)
+                or streamfield_resolver
             )
 
             # Add field to GQL type with correct field-type


### PR DESCRIPTION
## Overview

Grapple already supports callables in StreamFields (https://github.com/torchbox/wagtail-grapple/pull/220). This allows us to dynamically compute what to return when querying a field of a StreamField block.

Unfortunately, Grapple does now allow us to pass arguments to those callables. Such a functionality would be useful, however, when we want make the computation of the query result depend on some parameters provided by the user.

This PR implements support for callables in StreamFields so that we can make queries like the following, where `CustomBlock` is a StreamField block for which we want to add a GraphQL field `customizedField` that takes a string argument `extraArg`.

```gql
query($id: Int) {
    page(id: $id) {
        ... on BlogPage {
            body {
                ... on CustomBlock {
                    customizedField(extraArg: "hello")
                }
            }
        }
    }
}
```

## Implementation

When using `graphql_fields` for declaring the custom fields for a StreamField block, the field types are generated by the existing function `get_field_type(item)`, where `item` can be a `GraphQLField` or a tuple `(field, wrapper)`.
- If `item` is a `GraphQLField`, then the field is generated as `graphene.Field(field_type)`, where `field_type` is the appropriate type. Note that this does not declare any arguments.
- If `item` is a tuple `(field, wrapper)`, then the field is generated as `wrapper(field_type)`. With this mechanism, we can specify a wrapper that generates something like `graphene.Field(field_type, extra_arg=graphene.String())`.

Unfortunately the following does not work:

```python
@register_streamfield_block
class CustomBlock(blocks.StructBlock):
    graphql_fields = [
        (GraphQLString("customized_field", source="get_customized_field"),
         lambda field_type: graphene.Field(field_type, extra_arg=graphene.String())),
    ]

    def get_customized_field(self, values=None, extra_arg=None):
        return extra_arg  # or do something involving values
```

There are two reasons this does not work:

Firstly, Grapple does not take the field wrappers into account when generating resolvers. The resolvers are generated in `grapple.actions.build_streamfield_type` like this (abridged):

```python
if hasattr(cls, "graphql_fields"):
    for item in cls.graphql_fields:
        field, field_type = get_field_type(item)
        methods["resolve_" + field.field_name] = (
            custom_cls_resolver(cls=cls, graphql_field=item) or streamfield_resolver
        )
        type_meta[field.field_name] = field_type
```

Note that `graphql_field=item` is passed to `custom_cls_resolver`. This works if `item` is a `GraphQLField` but not if it is a tuple `(field, wrapper)`. (Grapple will fall back to the `streamfield_resolver`, which we do not want.) I suspect this is an oversight and fixed it by replacing `graphql_field=item` with `graphql_field=field`.

Secondly, when we define a field with custom arguments and implement the resolver with a callable, `custom_cls_resolver` does not supply the user-provided values for these arguments to the callable. This is easily fixed by passing `kwargs` along.

I added tests for this. Hopefully it's fine. Happy to improve further.