### PR TITLE
chore: update to graphiql 2.4.1

### DIFF
--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -9,7 +9,7 @@ from .settings import grapple_settings, has_channels
 def graphiql(request):
     graphiql_settings = {
         "REACT_VERSION": "18.2.0",
-        "GRAPHIQL_VERSION": "2.0.13",
+        "GRAPHIQL_VERSION": "2.4.1",
         "endpointURL": reverse("grapple_graphql"),
         "supports_subscriptions": has_channels,
     }


### PR DESCRIPTION
closes #104