### PR TITLE
Fix rendition definition

### DIFF
--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -111,6 +111,7 @@ need for Gatsby Image features to work (see Handy Fragments page for more info):
 ::
 
     id: ID!
+    collection: CollectionObjectType!
     title: String!
     file: String!
     width: Int!
@@ -122,12 +123,10 @@ need for Gatsby Image features to work (see Handy Fragments page for more info):
     focalPointHeight: Int
     fileSize: Int
     fileHash: String!
-    renditions: [ImageRenditionObjectType]
-    src: String
-    srcSet(
-        sizes: [Int]
-        format: String
-    ): String
+    url: String!
+    aspectRatio: Float!
+    sizes: String!
+    tags: [TagObjectType!]!
     rendition(
         max: String
         min: String
@@ -139,6 +138,11 @@ need for Gatsby Image features to work (see Handy Fragments page for more info):
         jpegquality: Int
         webpquality: Int
     ): ImageRenditionObjectType
+    srcSet(
+        sizes: [Int]
+        format: String
+    ): String
+
 
 
 ImageRenditions are useful feature in Wagtail and they exist in Grapple as well
@@ -146,14 +150,17 @@ the ``ImageRenditionObjectType`` provides the following fields:
 
 ::
 
-    id: ID
-    url: String
+    id: ID!
+    filter_spec = String!
     file: String!
-    width: Int
-    height: Int
-    aspectRatio: Float!
-    sizes: String!
+    width: Int!
+    height: Int!
+    focal_point_key = String!
     image: ImageObjectType!
+    focalPoint: String
+    url: String!
+    alt = String!
+    backgroundPositionStyle = String!
 
 
 DocumentObjectType

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -13,6 +13,15 @@ from .structures import QuerySetList
 from .tags import TagObjectType
 
 
+def get_image_type():
+    return registry.images.get(get_image_model(), ImageObjectType)
+
+
+def get_rendition_type():
+    rendition_mdl = get_image_model().renditions.rel.related_model
+    return registry.images.get(rendition_mdl, ImageRenditionObjectType)
+
+
 def rendition_allowed(rendition_filter):
     """Checks a given rendition filter is allowed"""
     allowed_filters = grapple_settings.ALLOWED_IMAGE_FILTERS
@@ -20,12 +29,6 @@ def rendition_allowed(rendition_filter):
         return True
 
     return rendition_filter in allowed_filters
-
-
-def get_rendition_type():
-    rendition_mdl = get_image_model().renditions.rel.related_model
-    rendition_type = registry.images.get(rendition_mdl, ImageRenditionObjectType)
-    return rendition_type
 
 
 class ImageRenditionObjectType(DjangoObjectType):
@@ -148,10 +151,6 @@ class ImageObjectType(DjangoObjectType):
             )
 
         return ""
-
-
-def get_image_type():
-    return registry.images.get(get_image_model(), ImageObjectType)
 
 
 def ImagesQuery():

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -108,22 +108,12 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
         filters = "|".join([f"{key}-{val}" for key, val in kwargs.items()])
 
         # Only allowed the defined filters (thus renditions)
-        if rendition_allowed(filters):
-            try:
-                img = self.get_rendition(filters)
-            except SourceImageIOError:
-                return
-
-            rendition_type = get_rendition_type()
-
-            return rendition_type(
-                id=img.id,
-                url=get_media_item_url(img),
-                width=img.width,
-                height=img.height,
-                file=img.file,
-                image=self,
-            )
+        if not rendition_allowed(filters):
+            return
+        try:
+            return self.get_rendition(filters)
+        except SourceImageIOError:
+            return
 
     def resolve_src_set(self, info, sizes, format=None, **kwargs):
         """

--- a/tests/test_grapple.py
+++ b/tests/test_grapple.py
@@ -1024,7 +1024,7 @@ class ImagesTest(BaseGrappleTest):
         )
         self.assertEqual(
             executed["data"]["images"][0]["rendition"]["url"],
-            self.example_image.get_rendition("width-200").file.url,
+            self.example_image.get_rendition("width-200").full_url,
         )
 
     def test_renditions(self):

--- a/tests/test_grapple.py
+++ b/tests/test_grapple.py
@@ -1024,8 +1024,7 @@ class ImagesTest(BaseGrappleTest):
         )
         self.assertEqual(
             executed["data"]["images"][0]["rendition"]["url"],
-            "http://localhost:8000"
-            + self.example_image.get_rendition("width-200").file.url,
+            self.example_image.get_rendition("width-200").file.url,
         )
 
     def test_renditions(self):
@@ -1035,6 +1034,7 @@ class ImagesTest(BaseGrappleTest):
             image(id: %d) {
                 rendition(width: 100) {
                     url
+                    customRenditionProperty
                 }
             }
         }
@@ -1044,6 +1044,10 @@ class ImagesTest(BaseGrappleTest):
 
         executed = self.client.execute(query)
         self.assertIn("width-100", executed["data"]["image"]["rendition"]["url"])
+        self.assertIn(
+            "Rendition Model!",
+            executed["data"]["image"]["rendition"]["customRenditionProperty"],
+        )
 
     @override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": ["width-200"]})
     def test_renditions_with_allowed_image_filters_restrictions(self):

--- a/tests/testapp/models/media.py
+++ b/tests/testapp/models/media.py
@@ -2,7 +2,7 @@ from django.db import models
 from wagtail.documents.models import AbstractDocument, Document
 from wagtail.images.models import AbstractImage, AbstractRendition, Image
 
-from grapple.models import GraphQLImage, GraphQLInt, GraphQLString
+from grapple.models import GraphQLString
 
 
 class CustomDocument(AbstractDocument):
@@ -34,12 +34,4 @@ class CustomImageRendition(AbstractRendition):
     def custom_rendition_property(self, info, **kwargs):
         return "Rendition Model!"
 
-    graphql_fields = (
-        GraphQLString("custom_rendition_property", required=True),
-        GraphQLInt("id", required=True),
-        GraphQLString("url", required=True),
-        GraphQLString("width", required=True),
-        GraphQLString("height", required=True),
-        GraphQLImage("image", required=True),
-        GraphQLString("file", required=True),
-    )
+    graphql_fields = (GraphQLString("custom_rendition_property", required=True),)


### PR DESCRIPTION
This PR:

- replaces #330
- add the correct Rendition object type to the registry
- adds a test for the custom rendition property
- avoids instantiating `ImageRenditionObjectType` in `ImageObjectType.get_rendition`
- updates schema in docs

