### PR TITLE
Consolidate handling when resolving Sites and avoid making assumptions about what data to return when it's ambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 ## Unreleased
 
+### Changed
+
+-   `GraphQLError` no longer raised when querying for a site by hostname that doesn't match any `Site`s (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342) - @kbayliss
+-   When querying pages with a site filter (e.g. `pages(site: "localhost")`) whose hostname does not match a `Site`, we no longer return pages for the first `Site` (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342) - @kbayliss
+-   When querying site setting/settings without a site filter (e.g. `setting(name: "SocialMediaSettings")`) and there are multiple `Site`s, we no longer return settings for the first `Site` (`GraphQLError` is raised instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342) - @kbayliss
+
 ## [0.19.2] - 2023-01-17
 
-## Fixed
+### Fixed
 
 -   Fix order_by_relevance needed for Postgres and queryset ordered searches ([#299](https://github.com/torchbox/wagtail-grapple/pull/299)) @dopry
 
 ## [0.19.1] - 2023-01-09
 
-## Fixed
+### Fixed
 
 -   An error when using deprecated settings. ([#298](https://github.com/torchbox/wagtail-grapple/pull/298)) Thanks @kbayliss for the heads up
 -   Previews for drafts ([#277](https://github.com/torchbox/wagtail-grapple/pull/277)) @dopry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Changed
 
--   `GraphQLError` no longer raised when querying for a site by hostname that doesn't match any `Site`s (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) - @kbayliss
--   When querying pages with a site filter (e.g. `pages(site: "localhost")`) whose hostname does not match a `Site`, we no longer return pages for the first `Site` (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) - @kbayliss
--   When querying site setting/settings without a site filter (e.g. `setting(name: "SocialMediaSettings")`) and there are multiple `Site`s, we no longer return settings for the first `Site` (`GraphQLError` is raised instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) - @kbayliss
+-   `GraphQLError` no longer raised when querying for a site by hostname that doesn't match any `Site`s (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) @kbayliss
+-   When querying pages with a site filter (e.g. `pages(site: "localhost")`) whose hostname does not match a `Site`, we no longer return pages for the first `Site` (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) @kbayliss
+-   When querying site setting/settings without a site filter (e.g. `setting(name: "SocialMediaSettings")`) and there are multiple `Site`s, we no longer return settings for the first `Site` (`GraphQLError` is raised instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) @kbayliss
 
 ## [0.19.2] - 2023-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Changed
 
--   `GraphQLError` no longer raised when querying for a site by hostname that doesn't match any `Site`s (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342) - @kbayliss
--   When querying pages with a site filter (e.g. `pages(site: "localhost")`) whose hostname does not match a `Site`, we no longer return pages for the first `Site` (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342) - @kbayliss
--   When querying site setting/settings without a site filter (e.g. `setting(name: "SocialMediaSettings")`) and there are multiple `Site`s, we no longer return settings for the first `Site` (`GraphQLError` is raised instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342) - @kbayliss
+-   `GraphQLError` no longer raised when querying for a site by hostname that doesn't match any `Site`s (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) - @kbayliss
+-   When querying pages with a site filter (e.g. `pages(site: "localhost")`) whose hostname does not match a `Site`, we no longer return pages for the first `Site` (`None` is returned instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) - @kbayliss
+-   When querying site setting/settings without a site filter (e.g. `setting(name: "SocialMediaSettings")`) and there are multiple `Site`s, we no longer return settings for the first `Site` (`GraphQLError` is raised instead) - ([#342](https://github.com/torchbox/wagtail-grapple/pull/342)) - @kbayliss
 
 ## [0.19.2] - 2023-01-17
 

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -283,7 +283,7 @@ def get_site_filter(info, **kwargs):
         )
 
     if site_hostname is not None:
-        return resolve_site(hostname=site_hostname)
+        return resolve_site(hostname=site_hostname, hostname_filter_name="site")
     elif in_current_site:
         return Site.find_for_request(info.context)
 

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -285,7 +285,7 @@ def get_site_filter(info, **kwargs):
     if site_hostname is not None:
         return resolve_site_by_hostname(
             hostname=site_hostname,
-            hostname_filter_name="site",
+            filter_name="site",
         )
     elif in_current_site:
         return Site.find_for_request(info.context)

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -8,7 +8,7 @@ from wagtail.models import Page as WagtailPage
 from wagtail.models import Site
 
 from ..registry import registry
-from ..utils import resolve_queryset, resolve_site
+from ..utils import resolve_queryset, resolve_site_by_hostname
 from .structures import QuerySetList
 
 
@@ -283,7 +283,10 @@ def get_site_filter(info, **kwargs):
         )
 
     if site_hostname is not None:
-        return resolve_site(hostname=site_hostname, hostname_filter_name="site")
+        return resolve_site_by_hostname(
+            hostname=site_hostname,
+            hostname_filter_name="site",
+        )
     elif in_current_site:
         return Site.find_for_request(info.context)
 

--- a/grapple/types/settings.py
+++ b/grapple/types/settings.py
@@ -4,7 +4,7 @@ from wagtail.contrib.settings.models import BaseGenericSetting, BaseSiteSetting
 from wagtail.models import Site
 
 from ..registry import registry
-from ..utils import resolve_site
+from ..utils import resolve_site_by_hostname
 
 
 def SettingsQuery():
@@ -35,8 +35,9 @@ def SettingsQuery():
                 site_hostname = kwargs.pop(site_hostname_kwarg, None)
 
                 if site_hostname is not None:
-                    site = resolve_site(
-                        hostname=site_hostname, hostname_filter_name=site_hostname_kwarg
+                    site = resolve_site_by_hostname(
+                        hostname=site_hostname,
+                        hostname_filter_name=site_hostname_kwarg,
                     )
                 else:
                     site = None
@@ -77,8 +78,9 @@ def SettingsQuery():
                 site_hostname = kwargs.pop(site_hostname_kwarg, None)
 
                 if site_hostname is not None:
-                    site = resolve_site(
-                        hostname=site_hostname, hostname_filter_name=site_hostname_kwarg
+                    site = resolve_site_by_hostname(
+                        hostname=site_hostname,
+                        hostname_filter_name=site_hostname_kwarg,
                     )
                 else:
                     site = None

--- a/grapple/types/settings.py
+++ b/grapple/types/settings.py
@@ -31,10 +31,13 @@ def SettingsQuery():
             def resolve_setting(self, info, **kwargs):
                 # Site filter
                 # Only applies to settings that inherit from BaseSiteSetting
-                site_hostname = kwargs.pop("site", None)
+                site_hostname_kwarg = "site"
+                site_hostname = kwargs.pop(site_hostname_kwarg, None)
 
                 if site_hostname is not None:
-                    site = resolve_site(hostname=site_hostname)
+                    site = resolve_site(
+                        hostname=site_hostname, hostname_filter_name=site_hostname_kwarg
+                    )
                 else:
                     site = None
 
@@ -70,10 +73,13 @@ def SettingsQuery():
             def resolve_settings(self, info, **kwargs):
                 # Site filter
                 # Only applies to settings that inherit from BaseSiteSetting
-                site_hostname = kwargs.pop("site", None)
+                site_hostname_kwarg = "site"
+                site_hostname = kwargs.pop(site_hostname_kwarg, None)
 
                 if site_hostname is not None:
-                    site = resolve_site(hostname=site_hostname)
+                    site = resolve_site(
+                        hostname=site_hostname, hostname_filter_name=site_hostname_kwarg
+                    )
                 else:
                     site = None
 

--- a/grapple/types/settings.py
+++ b/grapple/types/settings.py
@@ -1,5 +1,6 @@
 import graphene
-from wagtail.contrib.settings.models import BaseSiteSetting
+from graphql import GraphQLError
+from wagtail.contrib.settings.models import BaseGenericSetting, BaseSiteSetting
 from wagtail.models import Site
 
 from ..registry import registry
@@ -43,15 +44,27 @@ def SettingsQuery():
                     if name and setting._meta.model_name != name.lower():
                         continue
 
-                    if site and issubclass(setting._meta.model, BaseSiteSetting):
-                        return setting._meta.model.objects.filter(site=site).first()
+                    if issubclass(setting._meta.model, BaseSiteSetting):
+                        if site:
+                            return setting._meta.model.objects.filter(site=site).first()
+                        elif Site.objects.all().count() == 1:
+                            # If there's only one Site, we can reliably return
+                            # the correct (i.e. only) SiteSetting.
+                            return setting._meta.model.objects.first()
+                        else:
+                            # If there are multiple `Site`s, we don't know what
+                            # data to return.
+                            raise GraphQLError(
+                                f"There are multiple `{name}` instances - "
+                                "please include a `site` filter to disambiguate "
+                                f"(e.g. `setting(name: '{name}', site='example.com')`."
+                            )
 
-                    # If there's only one Site, we can reliably return the
-                    # correct SiteSetting here.
-                    if Site.objects.all().count() == 1:
+                    elif issubclass(setting._meta.model, BaseGenericSetting):
+                        # If it's a GenericSetting, there can only be one.
                         return setting._meta.model.objects.first()
-                    else:
-                        return None
+
+                    return None
 
             # Return all settings.
             def resolve_settings(self, info, **kwargs):

--- a/grapple/types/settings.py
+++ b/grapple/types/settings.py
@@ -37,7 +37,7 @@ def SettingsQuery():
                 if site_hostname is not None:
                     site = resolve_site_by_hostname(
                         hostname=site_hostname,
-                        hostname_filter_name=site_hostname_kwarg,
+                        filter_name=site_hostname_kwarg,
                     )
                 else:
                     site = None
@@ -80,7 +80,7 @@ def SettingsQuery():
                 if site_hostname is not None:
                     site = resolve_site_by_hostname(
                         hostname=site_hostname,
-                        hostname_filter_name=site_hostname_kwarg,
+                        filter_name=site_hostname_kwarg,
                     )
                 else:
                     site = None

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -90,7 +90,7 @@ def SitesQuery():
             elif hostname := kwargs.get("hostname"):
                 return resolve_site_by_hostname(
                     hostname=hostname,
-                    hostname_filter_name="hostname",
+                    filter_name="hostname",
                 )
             return None
 

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -81,12 +81,14 @@ def SitesQuery():
 
         def resolve_site(self, info, **kwargs) -> Optional[Site]:
             """
-            Return a single `Site` object, identified by ID or hostname.
+            Attempt to return a single `Site` object identified by ID or
+            hostname.
             """
 
             if id := kwargs.get("id"):
                 return resolve_site(id=id)
             elif hostname := kwargs.get("hostname"):
                 return resolve_site(hostname=hostname, hostname_filter_name="hostname")
+            return None
 
     return Mixin

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -8,7 +8,7 @@ from graphene_django.types import DjangoObjectType
 from wagtail.models import Page as WagtailPage
 from wagtail.models import Site
 
-from ..utils import resolve_queryset, resolve_site
+from ..utils import resolve_queryset, resolve_site_by_hostname, resolve_site_by_id
 from .pages import PageInterface, get_specific_page
 from .structures import QuerySetList
 
@@ -86,9 +86,12 @@ def SitesQuery():
             """
 
             if id := kwargs.get("id"):
-                return resolve_site(id=id)
+                return resolve_site_by_id(id=id)
             elif hostname := kwargs.get("hostname"):
-                return resolve_site(hostname=hostname, hostname_filter_name="hostname")
+                return resolve_site_by_hostname(
+                    hostname=hostname,
+                    hostname_filter_name="hostname",
+                )
             return None
 
     return Mixin

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -87,6 +87,6 @@ def SitesQuery():
             if id := kwargs.get("id"):
                 return resolve_site(id=id)
             elif hostname := kwargs.get("hostname"):
-                return resolve_site(hostname=hostname)
+                return resolve_site(hostname=hostname, hostname_filter_name="hostname")
 
     return Mixin

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -30,7 +30,7 @@ def resolve_site_by_id(
 def resolve_site_by_hostname(
     *,
     hostname: str,
-    hostname_filter_name: Literal["site", "hostname"],
+    filter_name: Literal["site", "hostname"],
 ) -> Optional[Site]:
     """
     Find a `Site` object by hostname.
@@ -60,9 +60,9 @@ def resolve_site_by_hostname(
         return Site.objects.get(**query)
     except Site.MultipleObjectsReturned as err:
         raise GraphQLError(
-            f"Your filter `{hostname_filter_name}={hostname}` returned "
+            f"Your filter `{filter_name}={hostname}` returned "
             "multiple sites. Try including a port number to disambiguate "
-            f"(e.g. `{hostname_filter_name}={hostname}:8000`)."
+            f"(e.g. `{filter_name}={hostname}:8000`)."
         ) from err
     except Site.DoesNotExist:
         # This is an expected error, so should not raise a GraphQLError.

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -18,7 +18,7 @@ def resolve_site(
     """
     Find a `Site` object by ID or hostname.
 
-    If resolving via hostname, and two `Site` records exist with the same
+    If resolving via hostname and two `Site` records exist with the same
     hostname, you must include the port to disambiguate.
 
     For example:

--- a/tests/test_grapple.py
+++ b/tests/test_grapple.py
@@ -1732,3 +1732,42 @@ class SettingsTest(BaseGrappleTest):
                 }
             },
         )
+
+    def test_query_single_setting_without_site_filter_and_multiple_sites(self):
+        # Create another site so that querying for `SocialMediaSettings` is
+        # ambiguous (i.e. which site should we be returning
+        # `SocialMediaSettings` for?)
+        wagtail_factories.SiteFactory()
+
+        query = """
+        {
+            setting(name: "SocialMediaSettings") {
+                ... on SocialMediaSettings {
+                    facebook
+                    instagram
+                    tripAdvisor
+                    youtube
+                }
+            }
+        }
+        """
+
+        response = self.client.execute(query)
+
+        self.assertEqual(
+            response,
+            {
+                "errors": [
+                    {
+                        "message": (
+                            "There are multiple `SocialMediaSettings` instances - "
+                            "please include a `site` filter to disambiguate "
+                            "(e.g. `setting(name: 'SocialMediaSettings', site='example.com')`."
+                        ),
+                        "locations": [{"column": 13, "line": 3}],
+                        "path": ["setting"],
+                    }
+                ],
+                "data": {"setting": None},
+            },
+        )

--- a/tests/test_grapple.py
+++ b/tests/test_grapple.py
@@ -231,9 +231,9 @@ class PagesTest(BaseGrappleTest):
                 "errors": [
                     {
                         "message": (
-                            f"Your `Site` filter `hostname={self.site_different_hostname.hostname}` returned "
+                            f"Your filter `site={self.site_different_hostname.hostname}` returned "
                             "multiple sites. Try including a port number to disambiguate "
-                            f"(e.g. `hostname={self.site_different_hostname.hostname}:8000`)."
+                            f"(e.g. `site={self.site_different_hostname.hostname}:8000`)."
                         ),
                         "locations": [{"line": 3, "column": 13}],
                         "path": ["pages"],
@@ -717,7 +717,7 @@ class SitesTest(TestCase):
                 "errors": [
                     {
                         "message": (
-                            f"Your `Site` filter `hostname={self.site_different_hostname.hostname}` returned "
+                            f"Your filter `hostname={self.site_different_hostname.hostname}` returned "
                             "multiple sites. Try including a port number to disambiguate "
                             f"(e.g. `hostname={self.site_different_hostname.hostname}:8000`)."
                         ),
@@ -1553,9 +1553,9 @@ class SettingsTest(BaseGrappleTest):
                 "errors": [
                     {
                         "message": (
-                            f"Your `Site` filter `hostname={self.site_b.hostname}` returned "
+                            f"Your filter `site={self.site_b.hostname}` returned "
                             "multiple sites. Try including a port number to disambiguate "
-                            f"(e.g. `hostname={self.site_b.hostname}:8000`)."
+                            f"(e.g. `site={self.site_b.hostname}:8000`)."
                         ),
                         "locations": [{"line": 3, "column": 13}],
                         "path": ["setting"],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,7 @@ class TestResolveSiteByHostname(TestCase):
         self.assertEqual(
             resolve_site_by_hostname(
                 hostname="example.com",
-                hostname_filter_name="hostname",
+                filter_name="hostname",
             ),
             site,
         )
@@ -66,7 +66,7 @@ class TestResolveSiteByHostname(TestCase):
         self.assertEqual(
             resolve_site_by_hostname(
                 hostname="example.com:1000",
-                hostname_filter_name="hostname",
+                filter_name="hostname",
             ),
             site,
         )
@@ -82,7 +82,7 @@ class TestResolveSiteByHostname(TestCase):
         self.assertEqual(
             resolve_site_by_hostname(
                 hostname="not.example.com",
-                hostname_filter_name="hostname",
+                filter_name="hostname",
             ),
             None,
         )
@@ -101,5 +101,5 @@ class TestResolveSiteByHostname(TestCase):
         ):
             resolve_site_by_hostname(
                 hostname="example.com",
-                hostname_filter_name="hostname",
+                filter_name="hostname",
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,7 +45,7 @@ class TestResolveSite(TestCase):
             site,
         )
 
-    def test_graphqlerror_when_query_is_ambiguous(self):
+    def test_graphqlerror_when_hostname_is_ambiguous(self):
         """
         Ensure a `GraphQLError` is returned when passing an ambiguous
         `hostname`.
@@ -59,9 +59,10 @@ class TestResolveSite(TestCase):
         ):
             resolve_site(hostname="example.com")
 
-    def test_response_is_none_when_query_is_ambiguous(self):
+    def test_response_is_none_when_no_sites_match_hostname(self):
         """
-        Ensure `None` is returned when passing an unknown `hostname`.
+        Ensure `None` is returned when passing a `hostname` that doesn't match
+        any `Site`s.
         """
 
         wagtail_factories.SiteFactory(hostname="example.com")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,85 @@
+import wagtail_factories
+from django.test import TestCase
+from graphql import GraphQLError
+
+from grapple.utils import resolve_site
+
+
+class TestResolveSite(TestCase):
+    """
+    Test suite for the `grapple.utils.resolve_site()` utility method.
+    """
+
+    def test_success_with_id(self):
+        """
+        Ensure passing a valid `id` returns the correct `Site` object.
+        """
+
+        site = wagtail_factories.SiteFactory(id=1)
+
+        self.assertEqual(resolve_site(id=1), site)
+
+    def test_success_with_ambiguous_hostname(self):
+        """
+        Ensure passing a valid `hostname` without port returns the correct
+        `Site` object when there is only one Site with the same hostname.
+        """
+
+        site = wagtail_factories.SiteFactory(hostname="example.com")
+
+        self.assertEqual(
+            resolve_site(hostname="example.com"),
+            site,
+        )
+
+    def test_success_with_hostname_and_port(self):
+        """
+        Ensure passing a valid `hostname` with port returns the correct `Site`
+        object.
+        """
+
+        site = wagtail_factories.SiteFactory(hostname="example.com", port="1000")
+
+        self.assertEqual(
+            resolve_site(hostname="example.com:1000"),
+            site,
+        )
+
+    def test_graphqlerror_when_query_is_ambiguous(self):
+        """
+        Ensure a `GraphQLError` is returned when passing an ambiguous
+        `hostname`.
+        """
+
+        wagtail_factories.SiteFactory(hostname="example.com", port="1000")
+        wagtail_factories.SiteFactory(hostname="example.com", port="2000")
+
+        with self.assertRaisesRegex(
+            GraphQLError, "Try including a port number to disambiguate"
+        ):
+            resolve_site(hostname="example.com")
+
+    def test_response_is_none_when_query_is_ambiguous(self):
+        """
+        Ensure `None` is returned when passing an unknown `hostname`.
+        """
+
+        wagtail_factories.SiteFactory(hostname="example.com")
+
+        self.assertEqual(resolve_site(hostname="not.example.com"), None)
+
+    def test_must_provide_id_or_hostname(self):
+        """
+        Ensure resolve_site() warns if used without `id` or `hostname`.
+        """
+
+        with self.assertRaises(TypeError):
+            resolve_site()
+
+    def test_cannot_provide_id_and_hostname(self):
+        """
+        Ensure resolve_site() warns if used with `id` and `hostname`.
+        """
+
+        with self.assertRaises(ValueError):
+            resolve_site(id=1000, hostname="example.com")

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -28,7 +28,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("wagtailcore", "0078_referenceindex"),
-        ("taggit", "0005_auto_20220424_2025"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("wagtailmedia", "0004_duration_optional_floatfield"),
     ]


### PR DESCRIPTION
https://github.com/torchbox/wagtail-grapple/issues/340 identifies that the handling of resolving sites is inconsistent depending on the context.

This MR addresses that so that:

1. A `GraphQLError` is no longer raised if querying for a `Site` with a hostname that doesn't exist (as this is an expected error) - similar to what already happens when querying for a `Site` by ID that doesn't exist
2. Consolidates the handling of site resolving to reduce code
3. We no longer return `Page`s for the first `Site` when querying for `Page`s with an erroneous `Site` filter (i.e. providing a `hostname=does.not.exist` query filter should not return `Page`s for the first `Site` - it should return `None`).
4. We no longer return `SiteSetting`s for the first `Site` when querying for `SiteSetting`s without a site filter when there are multiple `Site`s.

Also, I had to remove a migration dependency for `taggit` when initialising an empty database - I didn't look into why, though I did confirm that `taggit` migrations are still run as Wagtail requires 'em.
