### PR TITLE
Uniform ID Type for pages and page Queries

### DIFF
--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -80,7 +80,7 @@ The singular ``page`` field accepts the following arguments:
 
 .. code-block:: graphql
 
-    id: Int                       # Can be used on it's own
+    id: ID                        # Can be used on it's own
     slug: String                  # Can be used on it's own
     urlPath: String               # Can be used on it's own
     token: String                 # Must be used with one of the others. Usually contentType

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -74,7 +74,7 @@ def register_query_field(
         field_type = lambda: registry.models[cls]  # noqa: E731
         field_query_params = query_params
         if field_query_params is None:
-            field_query_params = {"id": graphene.Int()}
+            field_query_params = {"id": graphene.ID()}
 
             if issubclass(cls, Page):
                 field_query_params["slug"] = graphene.Argument(
@@ -194,7 +194,7 @@ def register_paginated_query_field(
         field_type = lambda: registry.models[cls]  # noqa: E731
         field_query_params = query_params
         if field_query_params is None:
-            field_query_params = {"id": graphene.Int()}
+            field_query_params = {"id": graphene.ID()}
 
             if issubclass(cls, Page):
                 field_query_params["slug"] = graphene.Argument(

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -334,7 +334,7 @@ def PagesQuery():
         )
         page = graphene.Field(
             PageInterface,
-            id=graphene.Int(),
+            id=graphene.ID(),
             slug=graphene.String(),
             url_path=graphene.Argument(
                 graphene.String,

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -26,7 +26,7 @@ class SiteObjectType(DjangoObjectType):
     )
     page = graphene.Field(
         PageInterface,
-        id=graphene.Int(),
+        id=graphene.ID(),
         slug=graphene.String(),
         url_path=graphene.String(),
         token=graphene.String(),

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -136,7 +136,7 @@ class BlogTest(BaseGrappleTest):
 
     def test_blog_page(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     title
@@ -151,7 +151,7 @@ class BlogTest(BaseGrappleTest):
 
     def test_related_author_page(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     author {
@@ -171,7 +171,7 @@ class BlogTest(BaseGrappleTest):
 
     def get_blocks_from_body(self, block_type, block_query="rawValue", page_id=None):
         query = f"""
-        query($id: Int) {{
+        query($id: ID) {{
             page(id: $id) {{
                 ... on BlogPage {{
                     body {{
@@ -248,7 +248,7 @@ class BlogTest(BaseGrappleTest):
 
     def test_richtext(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     summary
@@ -471,7 +471,7 @@ class BlogTest(BaseGrappleTest):
 
     def test_blog_embed(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     body {
@@ -656,7 +656,7 @@ class BlogTest(BaseGrappleTest):
     # Next 2 tests are used to test the Collection API, both ForeignKey and nested field extraction.
     def test_blog_page_related_links(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     relatedLinks {
@@ -676,7 +676,7 @@ class BlogTest(BaseGrappleTest):
 
     def test_blog_page_related_urls(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     relatedUrls
@@ -696,7 +696,7 @@ class BlogTest(BaseGrappleTest):
         per_page = 5
 
         query = """
-        query ($id: Int, $page: PositiveInt, $perPage: PositiveInt) {
+        query ($id: ID, $page: PositiveInt, $perPage: PositiveInt) {
             page(id: $id) {
                 ... on BlogPage {
                     paginatedAuthors(page: $page, perPage: $perPage) {
@@ -905,7 +905,7 @@ class BlogTest(BaseGrappleTest):
 
     def test_blog_page_tags(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     tags {
@@ -1057,7 +1057,7 @@ class BlogTest(BaseGrappleTest):
 
     def test_custom_property(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     customProperty

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -104,7 +104,7 @@ class TestRegisterQueryField(BaseGrappleTest):
 
     def test_query_field(self):
         query = """
-        query ($id: Int, $urlPath: String, $slug: String) {
+        query ($id: ID, $urlPath: String, $slug: String) {
             post(id: $id, urlPath: $urlPath, slug: $slug) {
                 id
                 urlPath
@@ -148,7 +148,7 @@ class TestRegisterQueryField(BaseGrappleTest):
 
     def test_multiple_middleware(self):
         query = """
-        query ($id: Int) {
+        query ($id: ID) {
             middlewareModel(id: $id) {
                 id
             }
@@ -178,7 +178,7 @@ class TestRegisterPaginatedQueryField(BaseGrappleTest):
 
     def test_paginated_query_field(self):
         query = """
-        query ($id: Int, $urlPath: String, $slug: String) {
+        query ($id: ID, $urlPath: String, $slug: String) {
             blogPage(id: $id, urlPath: $urlPath, slug: $slug) {
                 id
                 urlPath
@@ -476,7 +476,7 @@ class TestFieldMiddleware(BaseGrappleTest):
         """
 
         query = """
-        query ($id: Int) {
+        query ($id: ID) {
             post(id: $id) {
                 id
                 urlPath
@@ -514,7 +514,7 @@ class TestFieldMiddleware(BaseGrappleTest):
         The query field was registered with the anonymous middleware, i.e. requires only anonymous users
         """
         query = """
-        query ($id: Int) {
+        query ($id: ID) {
             blogPage(id: $id) {
                 id
                 urlPath

--- a/tests/test_grapple.py
+++ b/tests/test_grapple.py
@@ -352,7 +352,7 @@ class PagesTest(BaseGrappleTest):
 
     def test_page(self):
         query = """
-        query($id: Int) {
+        query($id: ID) {
             page(id: $id) {
                 contentType
                 parent {


### PR DESCRIPTION
Currently, in the Wagtail GraphQL API of wagtail-grapple, there is an inconsistency in the input types for the `pages` and `page` queries. While the `pages` query expects an `ID` as an input, the `page` query expects an `Int`. This has been leading to unnecessary conversion between string and integer.

#### Proposed Changes
I propose to make the input types consistent by changing the `id` in the `page` query to be of type `ID` (the same as in the `pages` query).

The change can be made in the following file:
[grapple/types/pages.py#L336](https://github.com/torchbox/wagtail-grapple/blob/a40354200a5977bb792cad73d8f667e297666eae/grapple/types/pages.py#L336)

By changing the return type to `graphene.ID`, it ensures uniformity across the queries and eradicates the need for conversions between string and integer.

I updated the documentation as well. 

