### PR TITLE
SteamField block extra interfaces (part 1)

### DIFF
--- a/docs/general-usage/decorators.rst
+++ b/docs/general-usage/decorators.rst
@@ -422,3 +422,18 @@ To extend the schema with custom StreamField block types, the ``register_streamf
             graphql_description = "This is a streamblock with a textblock child"
 
 If a block's ``Meta`` class has a ``graphql_description`` attribute, this value will be exposed as the ``description`` in introspection queries.
+
+To register additional interfaces for the block, add them with the ``interfaces`` argument:
+
+.. code-block:: python
+
+    import graphene
+
+
+    class CustomBlockInterface(graphene.Interface):
+        text = graphene.String()
+
+
+    @register_streamfield_block(interfaces=(CustomBlockInterface,))
+    class BlockWithCustomInterface(blocks.StructBlock):
+        text = blocks.TextBlock()

--- a/docs/general-usage/decorators.rst
+++ b/docs/general-usage/decorators.rst
@@ -430,10 +430,10 @@ To register additional interfaces for the block, add them with the ``interfaces`
     import graphene
 
 
-    class CustomBlockInterface(graphene.Interface):
+    class CustomInterface(graphene.Interface):
         text = graphene.String()
 
 
-    @register_streamfield_block(interfaces=(CustomBlockInterface,))
-    class BlockWithCustomInterface(blocks.StructBlock):
+    @register_streamfield_block(interfaces=(CustomInterface,))
+    class CustomInterfaceBlock(blocks.StructBlock):
         text = blocks.TextBlock()

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -2,7 +2,7 @@ import inspect
 
 from collections.abc import Iterable
 from types import MethodType
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, Tuple, Type, Union
 
 import graphene
 
@@ -80,7 +80,7 @@ def import_apps():
         node_type = build_streamfield_type(
             cls,
             streamfield_type["type_prefix"],
-            streamfield_type["interface"],
+            streamfield_type["interfaces"],
             base_type,
         )
 
@@ -448,13 +448,16 @@ def custom_cls_resolver(*, cls, graphql_field):
 def build_streamfield_type(
     cls: type,
     type_prefix: str,
-    interface: graphene.Interface,
+    interfaces: Tuple[graphene.Interface],
     base_type=graphene.ObjectType,
 ):
     """
     Build a graphql type for a StreamBlock or StructBlock class
     If it has custom fields then implement them.
     """
+
+    # Alias the argument name so we can use it in the class block
+    interfaces_ = interfaces
 
     # Create a new blank node type
     class Meta:
@@ -463,7 +466,7 @@ def build_streamfield_type(
                 registry.streamfield_blocks.get(block) for block in cls.graphql_types
             ]
         else:
-            interfaces = (interface,) if interface is not None else ()
+            interfaces = interfaces_ if interfaces_ is not None else ()
         # Add description to type if the Meta class declares it
         description = getattr(cls._meta_class, "graphql_description", None)
 

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -17,22 +17,28 @@ streamfield_types = []
 field_middlewares = {}
 
 
-def register_streamfield_block(cls):
-    base_block = None
-    for block_class in inspect.getmro(cls):
-        if block_class in registry.streamfield_blocks:
-            base_block = registry.streamfield_blocks[block_class]
+def register_streamfield_block(cls=None, extra_interfaces=()):
+    def decorator(cls):
+        base_block = None
+        for block_class in inspect.getmro(cls):
+            if block_class in registry.streamfield_blocks:
+                base_block = registry.streamfield_blocks[block_class]
 
-    streamfield_types.append(
-        {
-            "cls": cls,
-            "type_prefix": "",
-            "interfaces": (StreamFieldInterface,),
-            "base_type": base_block,
-        }
-    )
+        streamfield_types.append(
+            {
+                "cls": cls,
+                "type_prefix": "",
+                "interfaces": (StreamFieldInterface, *extra_interfaces),
+                "base_type": base_block,
+            }
+        )
 
-    return cls
+        return cls
+
+    if isinstance(cls, type) and not extra_interfaces:
+        return decorator(cls)
+
+    return decorator
 
 
 def register_graphql_schema(schema_cls):

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -17,7 +17,7 @@ streamfield_types = []
 field_middlewares = {}
 
 
-def register_streamfield_block(cls=None, extra_interfaces=()):
+def register_streamfield_block(klass=None, interfaces=()):
     def decorator(cls):
         base_block = None
         for block_class in inspect.getmro(cls):
@@ -28,15 +28,15 @@ def register_streamfield_block(cls=None, extra_interfaces=()):
             {
                 "cls": cls,
                 "type_prefix": "",
-                "interfaces": (StreamFieldInterface, *extra_interfaces),
+                "interfaces": tuple({StreamFieldInterface, *interfaces}),
                 "base_type": base_block,
             }
         )
 
         return cls
 
-    if isinstance(cls, type) and not extra_interfaces:
-        return decorator(cls)
+    if isinstance(klass, type) and not interfaces:
+        return decorator(klass)
 
     return decorator
 

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -27,7 +27,7 @@ def register_streamfield_block(cls):
         {
             "cls": cls,
             "type_prefix": "",
-            "interface": StreamFieldInterface,
+            "interfaces": (StreamFieldInterface,),
             "base_type": base_block,
         }
     )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 # Test requirements.
 black>=23.7.0
-ruff=0.0.285
+ruff==0.0.285
 
 # Runtime requirements
 Django>=3.2,<5.0

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1225,7 +1225,9 @@ class BlogTest(BaseGrappleTest):
 
         for block in body:
             if block["blockType"] == "CustomInterfaceBlock":
-                self.assertRegex(block["customText"], r"^Block with custom interface \d+$")
+                self.assertRegex(
+                    block["customText"], r"^Block with custom interface \d+$"
+                )
                 return
 
         self.fail("Query by interface didn't match anything")

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -1212,7 +1212,7 @@ class BlogTest(BaseGrappleTest):
                 ... on BlogPage {
                     body {
                         blockType
-                        ...on CustomInterfaceForBlock {
+                        ...on CustomBlockInterface {
                             customText
                         }
                     }

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -19,8 +19,8 @@ from testapp.blocks import (
 )
 from testapp.factories import (
     AdvertFactory,
-    BlockWithCustomInterfaceFactory,
     BlogPageFactory,
+    CustomInterfaceBlockFactory,
     PersonFactory,
     TextWithCallableBlockFactory,
 )
@@ -129,7 +129,7 @@ class BlogTest(BaseGrappleTest):
                     },
                 ),
                 ("text_with_callable", TextWithCallableBlockFactory()),
-                ("block_with_custom_interface", BlockWithCustomInterfaceFactory()),
+                ("custom_interface_block", CustomInterfaceBlockFactory()),
             ],
             parent=self.home,
             summary=self.richtext_sample,
@@ -1205,14 +1205,14 @@ class BlogTest(BaseGrappleTest):
         response = self.client.execute(query)
         self.assertIsNone(response["data"]["__type"]["description"])
 
-    def test_block_with_custom_interface(self):
+    def test_custom_interface_block(self):
         query = """
         query($id: ID) {
             page(id: $id) {
                 ... on BlogPage {
                     body {
                         blockType
-                        ...on CustomBlockInterface {
+                        ...on CustomInterface {
                             customText
                         }
                     }
@@ -1224,8 +1224,8 @@ class BlogTest(BaseGrappleTest):
         body = executed["data"]["page"]["body"]
 
         for block in body:
-            if block["blockType"] == "BlockWithCustomInterface":
-                self.assertEqual(block["customText"], "Block with custom interface 1")
+            if block["blockType"] == "CustomInterfaceBlock":
+                self.assertRegex(block["customText"], r"^Block with custom interface \d+$")
                 return
 
         self.fail("Query by interface didn't match anything")

--- a/tests/testapp/blocks.py
+++ b/tests/testapp/blocks.py
@@ -291,6 +291,23 @@ class TextWithCallableBlock(blocks.StructBlock):
         return ""
 
 
+class CustomInterfaceForBlock(graphene.Interface):
+    custom_text = graphene.String()
+
+
+@register_streamfield_block(extra_interfaces=(CustomInterfaceForBlock,))
+class BlockWithCustomInterface(blocks.StructBlock):
+    """
+    Specify a custom GraphQL interface for our block.
+    """
+
+    custom_text = blocks.TextBlock()
+
+    graphql_fields = [
+        GraphQLString("custom_text"),
+    ]
+
+
 class StreamFieldBlock(blocks.StreamBlock):
     heading = blocks.CharBlock(classname="full title")
     paragraph = blocks.RichTextBlock()
@@ -309,3 +326,4 @@ class StreamFieldBlock(blocks.StreamBlock):
     block_with_name = BlockWithName()
     advert = SnippetChooserBlock("testapp.Advert")
     person = SnippetChooserBlock("testapp.Person")
+    block_with_custom_interface = BlockWithCustomInterface()

--- a/tests/testapp/blocks.py
+++ b/tests/testapp/blocks.py
@@ -291,11 +291,11 @@ class TextWithCallableBlock(blocks.StructBlock):
         return ""
 
 
-class CustomInterfaceForBlock(graphene.Interface):
+class CustomBlockInterface(graphene.Interface):
     custom_text = graphene.String()
 
 
-@register_streamfield_block(extra_interfaces=(CustomInterfaceForBlock,))
+@register_streamfield_block(interfaces=(CustomBlockInterface,))
 class BlockWithCustomInterface(blocks.StructBlock):
     """
     Specify a custom GraphQL interface for our block.

--- a/tests/testapp/blocks.py
+++ b/tests/testapp/blocks.py
@@ -291,12 +291,12 @@ class TextWithCallableBlock(blocks.StructBlock):
         return ""
 
 
-class CustomBlockInterface(graphene.Interface):
+class CustomInterface(graphene.Interface):
     custom_text = graphene.String()
 
 
-@register_streamfield_block(interfaces=(CustomBlockInterface,))
-class BlockWithCustomInterface(blocks.StructBlock):
+@register_streamfield_block(interfaces=(CustomInterface,))
+class CustomInterfaceBlock(blocks.StructBlock):
     """
     Specify a custom GraphQL interface for our block.
     """
@@ -326,4 +326,4 @@ class StreamFieldBlock(blocks.StreamBlock):
     block_with_name = BlockWithName()
     advert = SnippetChooserBlock("testapp.Advert")
     person = SnippetChooserBlock("testapp.Person")
-    block_with_custom_interface = BlockWithCustomInterface()
+    custom_interface_block = CustomInterfaceBlock()

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -11,6 +11,7 @@ from testapp.blocks import (
     ImageGalleryImage,
     ImageGalleryImages,
     TextWithCallableBlock,
+    BlockWithCustomInterface,
 )
 from testapp.models import (
     Advert,
@@ -83,6 +84,13 @@ class TextWithCallableBlockFactory(wagtail_factories.StructBlockFactory):
 
     class Meta:
         model = TextWithCallableBlock
+
+
+class BlockWithCustomInterfaceFactory(wagtail_factories.StructBlockFactory):
+    custom_text = factory.Sequence(lambda n: f"Block with custom interface {n}")
+
+    class Meta:
+        model = BlockWithCustomInterface
 
 
 class BlogPageRelatedLinkFactory(factory.django.DjangoModelFactory):

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -7,7 +7,7 @@ from factory import fuzzy
 from wagtail import blocks
 
 from testapp.blocks import (
-    BlockWithCustomInterface,
+    CustomInterfaceBlock,
     ImageGalleryBlock,
     ImageGalleryImage,
     ImageGalleryImages,
@@ -86,11 +86,11 @@ class TextWithCallableBlockFactory(wagtail_factories.StructBlockFactory):
         model = TextWithCallableBlock
 
 
-class BlockWithCustomInterfaceFactory(wagtail_factories.StructBlockFactory):
+class CustomInterfaceBlockFactory(wagtail_factories.StructBlockFactory):
     custom_text = factory.Sequence(lambda n: f"Block with custom interface {n}")
 
     class Meta:
-        model = BlockWithCustomInterface
+        model = CustomInterfaceBlock
 
 
 class BlogPageRelatedLinkFactory(factory.django.DjangoModelFactory):

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -7,11 +7,11 @@ from factory import fuzzy
 from wagtail import blocks
 
 from testapp.blocks import (
+    BlockWithCustomInterface,
     ImageGalleryBlock,
     ImageGalleryImage,
     ImageGalleryImages,
     TextWithCallableBlock,
-    BlockWithCustomInterface,
 )
 from testapp.models import (
     Advert,


### PR DESCRIPTION
Refs. https://github.com/torchbox/wagtail-grapple/issues/231

Allow specifying extra interfaces when registering a streamfield block:

```py
@register_streamfield_block(extra_interfaces=(CustomInterfaceForBlock,))
class BlockWithCustomInterface(blocks.StructBlock):
    # ...
```
