### PR TITLE
Use the official black pre-commit mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: check-added-large-files
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.0.286'
+    rev: 'v0.0.287'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -30,7 +30,7 @@ repos:
     rev: 1.16.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.7.0]
+        additional_dependencies: [black==23.9.1]
   - repo: https://github.com/rtts/djhtml
     rev: 3.0.6
     hooks:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 # Test requirements.
-black>=23.7.0
-ruff==0.0.285
+black>=23.9.1
+ruff==0.0.287
 
 # Runtime requirements
 Django>=3.2,<5.0


### PR DESCRIPTION
and other minor version bumps

According to https://github.com/psf/black/releases/tag/23.9.0, this should be about 2x faster