### PR TITLE
Fixed test failing for wagtail 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- Fixed `test_src_set_invalid_format` not working with Wagtail 5.2 and above. @JakubMastalerz
+
 ## [0.23.0] - 2023-09-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Fixed `test_src_set_invalid_format` not working with Wagtail 5.2 and above. ([#378](https://github.com/torchbox/wagtail-grapple/pull/378)) @JakubMastalerz
+- `test_src_set_invalid_format` not working with Wagtail 5.2 and above. ([#378](https://github.com/torchbox/wagtail-grapple/pull/378)) @JakubMastalerz
 
 ## [0.23.0] - 2023-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Fixed `test_src_set_invalid_format` not working with Wagtail 5.2 and above. @JakubMastalerz
+- Fixed `test_src_set_invalid_format` not working with Wagtail 5.2 and above. ([#378](https://github.com/torchbox/wagtail-grapple/pull/378)) @JakubMastalerz
 
 ## [0.23.0] - 2023-09-29
 

--- a/tests/test_image_types.py
+++ b/tests/test_image_types.py
@@ -154,9 +154,15 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
 
     @skipIf(
         WAGTAIL_VERSION >= (5, 2),
-        "Wagtail 5.2 introduced changes to this error message.",
+        "Exception message is different in Wagtail 5.2+",
     )
     def test_src_set_invalid_format_wagtail_below_5_2(self):
+        """
+        Ensure that an exception is raised when image format is not of valid type.
+        Works with Wagtail versions below 5.2. For versions 5.2 and above see:
+        `test_src_set_invalid_format_wagtail_above_5_2`.
+        """
+
         query = """
         query ($id: ID!) {
             image(id: $id) {
@@ -171,9 +177,15 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
 
     @skipIf(
         WAGTAIL_VERSION < (5, 2),
-        "Wagtail 5.2 introduced changes to this error message.",
+        "Exception message is different in Wagtail verions below 5.2",
     )
     def test_src_set_invalid_format_wagtail_above_5_2(self):
+        """
+        Ensure that an exception is raised when image format is not of valid type.
+        Works with Wagtail versions 5.2 and above. For versions below 5.2 see:
+        `test_src_set_invalid_format_wagtail_below_5_2`.
+        """
+
         query = """
         query ($id: ID!) {
             image(id: $id) {

--- a/tests/test_image_types.py
+++ b/tests/test_image_types.py
@@ -156,7 +156,7 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
         WAGTAIL_VERSION >= (5, 2),
         "Wagtail 5.2 introduced changes to this error message.",
     )
-    def test_src_set_invalid_format(self):
+    def test_src_set_invalid_format_wagtail_below_5_2(self):
         query = """
         query ($id: ID!) {
             image(id: $id) {
@@ -173,7 +173,7 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
         WAGTAIL_VERSION < (5, 2),
         "Wagtail 5.2 introduced changes to this error message.",
     )
-    def test_src_set_invalid_format_wagtail_5(self):
+    def test_src_set_invalid_format_wagtail_above_5_2(self):
         query = """
         query ($id: ID!) {
             image(id: $id) {


### PR DESCRIPTION
Closes https://github.com/torchbox/wagtail-grapple/issues/377

This fixes `test_src_set_invalid_format` for Wagtail versions above 5.2 by:

- Adding a new test case for those versions, with updated error message.
- Adding conditional skipping based on active Wagtail version.