### PR TITLE
Avoid using hardcoded localhost in Redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 
 ### Changed
 
--   `new_url` field on `RedirectType` is no longer required ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
--   `old_url` field on `RedirectType` now returns url if site is specified and list of urls for all sites if not. ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   Renamed `RedirectType` to `RedirectObjectType` for clarity ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   `new_url` field on `RedirectObjectType` is no longer required ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   `old_url` field on `RedirectObjectType` now returns url if site is specified and list of urls for all sites if not. ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 -   Factory for `Redirect` model in test app ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
 -   Test suite for `Redirect` behaviour ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   `site` field on `RedirectObjectType` ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
 
 ### Changed
 
 -   Renamed `RedirectType` to `RedirectObjectType` for clarity ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
 -   `new_url` field on `RedirectObjectType` is no longer required ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
--   `old_url` field on `RedirectObjectType` now returns url if site is specified and list of urls for all sites if not. ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   `RedirectsQuery` now returns a separate redirect object for each existing site when `site=None` ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Added
 
--   Factory for `Redirect` model in test app ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @jakubmastalerz
+-   Factory for `Redirect` model in test app ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
+-   Test suite for `Redirect` behaviour ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
+
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 -   Factory for `Redirect` model in test app ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
 -   Test suite for `Redirect` behaviour ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
 
+### Changed
 
+-   `newUrl` field on `RedirectType` is no longer required ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## Unreleased
 
+### Added
+
+-   Factory for `Redirect` model in test app ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @jakubmastalerz
+
 ### Fixed
 
 - `test_src_set_invalid_format` not working with Wagtail 5.2 and above. ([#378](https://github.com/torchbox/wagtail-grapple/pull/378)) @JakubMastalerz
+
 
 ## [0.23.0] - 2023-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,11 @@
 ## Unreleased
 
-### Added
-
--   Factory for `Redirect` model in test app ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
--   Test suite for `Redirect` behaviour ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
--   `site` field on `RedirectObjectType` ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
-
 ### Changed
 
--   Renamed `RedirectType` to `RedirectObjectType` for clarity ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
--   `new_url` field on `RedirectObjectType` is no longer required ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
--   `RedirectsQuery` now returns a separate redirect object for each existing site when `site=None` ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
-
+-   Renamed `RedirectType` to `RedirectObjectType` ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   `RedirectsQuery` now returns a `Redirect` for each associated `Site` ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+    -   Added `site` field on `RedirectObjectType`
+    -   Changed `new_url` field on `RedirectObjectType` to be optional
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ### Added
 
--   Factory for `Redirect` model in test app ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
--   Test suite for `Redirect` behaviour ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
+-   Factory for `Redirect` model in test app ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   Test suite for `Redirect` behaviour ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
 
 ### Changed
 
--   `newUrl` field on `RedirectType` is no longer required ([tba](https://github.com/torchbox/wagtail-grapple/pull/tba)) @JakubMastalerz
+-   `new_url` field on `RedirectType` is no longer required ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+-   `old_url` field on `RedirectType` now returns url if site is specified and list of urls for all sites if not. ([#380](https://github.com/torchbox/wagtail-grapple/pull/380)) @JakubMastalerz
+
 
 ### Fixed
 

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -10,7 +10,7 @@ from wagtail.models import Page, Site
 from .pages import get_page_interface
 
 
-class RedirectType(graphene.ObjectType):
+class RedirectObjectType(graphene.ObjectType):
     old_path = graphene.String(required=True)
     old_url = graphene.String(required=True)
     new_url = graphene.String(required=False)
@@ -50,9 +50,12 @@ class RedirectType(graphene.ObjectType):
         if self.redirect_page is not None:
             return self.redirect_page.specific
 
+    class Meta:
+        name = "Redirect"
+
 
 class RedirectsQuery:
-    redirects = graphene.List(graphene.NonNull(RedirectType), required=True)
+    redirects = graphene.List(graphene.NonNull(RedirectObjectType), required=True)
 
     # Return all redirects.
     def resolve_redirects(self, info, **kwargs):

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -29,7 +29,7 @@ class RedirectObjectType(graphene.ObjectType):
         site and `old_path`.
         """
 
-        return f"{self.site.root_url}/{self.old_path}"
+        return self.site.root_url + self.old_path
 
     def resolve_new_url(self, info, **kwargs) -> Optional[str]:
         """

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -7,6 +7,8 @@ import graphene
 from wagtail.contrib.redirects.models import Redirect
 from wagtail.models import Page, Site
 
+from grapple.types.sites import SiteObjectType
+
 from .pages import get_page_interface
 
 
@@ -15,6 +17,7 @@ class RedirectObjectType(graphene.ObjectType):
     old_url = graphene.String(required=True)
     new_url = graphene.String(required=False)
     page = graphene.Field(get_page_interface())
+    site = graphene.Field(SiteObjectType, required=False)
     is_permanent = graphene.Boolean(required=True)
 
     def resolve_old_url(self, info, **kwargs) -> str:
@@ -23,8 +26,9 @@ class RedirectObjectType(graphene.ObjectType):
         Otherwise, return a JSON string representing a list of all site urls.
         """
         if self.site:
-            return f"http://{self.site.hostname}:{self.site.port}/{self.old_path}"
+            return f"{self.site.root_url}/{self.old_path}"
 
+        # TODO: Remove after making site required
         if self.site is None:
             sites_QS = Site.objects.all()
             old_url_list = []

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 import graphene
 
 from django.conf import settings
 from wagtail.contrib.redirects.models import Redirect
+from wagtail.models import Page
 
 from .pages import get_page_interface
 
@@ -9,23 +12,26 @@ from .pages import get_page_interface
 class RedirectType(graphene.ObjectType):
     old_path = graphene.String(required=True)
     old_url = graphene.String(required=True)
-    new_url = graphene.String(required=True)
+    new_url = graphene.String(required=False)
     page = graphene.Field(get_page_interface())
     is_permanent = graphene.Boolean(required=True)
 
     # Give old_path with BASE_URL attached.
-    def resolve_old_url(self, info, **kwargs):
+    def resolve_old_url(self, info, **kwargs) -> str:
         return settings.BASE_URL + self.old_path
 
     # Get new url
-    def resolve_new_url(self, info, **kwargs):
-        if self.redirect_page is None:
+    def resolve_new_url(self, info, **kwargs) -> Optional[str]:
+        if self.redirect_page:
+            return self.redirect_page.url
+
+        if self.link:
             return self.link
 
-        return self.redirect_page.url
+        return None
 
     # Return the page that's being redirected to, if at all.
-    def resolve_page(self, info, **kwargs):
+    def resolve_page(self, info, **kwargs) -> Optional[Page]:
         if self.redirect_page is not None:
             return self.redirect_page.specific
 

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -17,7 +17,9 @@ class RedirectObjectType(graphene.ObjectType):
     old_url = graphene.String(required=True)
     new_url = graphene.String(required=False)
     page = graphene.Field(get_page_interface())
-    site = graphene.Field(SiteObjectType, required=True)
+    site = graphene.Field(
+        SiteObjectType, required=True
+    )  # Required because `RedirectsQuery` always adds a value.
     is_permanent = graphene.Boolean(required=True)
 
     class Meta:
@@ -33,8 +35,8 @@ class RedirectObjectType(graphene.ObjectType):
 
     def resolve_new_url(self, info, **kwargs) -> Optional[str]:
         """
-        Resolve the value of `new_url`. If `redirect_page` is specified then it's
-        url is prioritised.
+        Resolve the value of `new_url`. If `redirect_page` is specified then its
+        URL is prioritised.
         """
 
         return self.link
@@ -61,14 +63,13 @@ class RedirectsQuery:
             .select_related("site")
             .all()
         )
-        finalised_redirects: list[
-            Redirect
-        ] = []  # Redirects to return within API response.
+        finalised_redirects: list[Redirect] = []  # Redirects to return in API.
+
         for redirect in redirects_qs:
             if redirect.site is None:
                 # Duplicate Redirect for each Site as it applies to all Sites.
                 for site in Site.objects.all():
-                    _new_redirect = copy.copy(redirect)
+                    _new_redirect = copy.deepcopy(redirect)
                     _new_redirect.site = site
                     finalised_redirects.append(_new_redirect)
             else:

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -17,30 +17,24 @@ class RedirectObjectType(graphene.ObjectType):
     old_url = graphene.String(required=True)
     new_url = graphene.String(required=False)
     page = graphene.Field(get_page_interface())
-    site = graphene.Field(SiteObjectType, required=False)
+    site = graphene.Field(SiteObjectType, required=True)
     is_permanent = graphene.Boolean(required=True)
 
     def resolve_old_url(self, info, **kwargs) -> str:
         """
         Resolve the value of `old_url` using the `root_url` of the associated
         site and `old_path`.
-        Note: `self.site` should never be none because of `resolve_redirects`.
         """
-        if self.site:
-            return f"{self.site.root_url}/{self.old_path}"
 
-        if self.site is None:
-            return None
+        return f"{self.site.root_url}/{self.old_path}"
 
-    # Get new url
     def resolve_new_url(self, info, **kwargs) -> Optional[str]:
-        if self.redirect_page:
-            return self.redirect_page.url
+        """
+        Resolve the value of `new_url`. If `redirect_page` is specified then it's
+        url is prioritised.
+        """
 
-        if self.link:
-            return self.link
-
-        return None
+        return self.link
 
     # Return the page that's being redirected to, if at all.
     def resolve_page(self, info, **kwargs) -> Optional[Page]:
@@ -55,22 +49,24 @@ class RedirectsQuery:
     redirects = graphene.List(graphene.NonNull(RedirectObjectType), required=True)
 
     # Return all redirects.
-    def resolve_redirects(self, info, **kwargs):
+    def resolve_redirects(self, info, **kwargs) -> list[Redirect]:
         """
         Resolve the query set of redirects. If `site` is None, a redirect works
         for all sites. To show this, a new redirect object is created for each
         of the sites.
         """
-        redirects_QS = Redirect.objects.select_related("redirect_page")
-        redirect_list = list(redirects_QS)
-        sites_QS = Site.objects.all()
-        for redirect in redirect_list:
+
+        redirects_qs = Redirect.objects.select_related("redirect_page").all()
+        finalised_redirects: list[
+            Redirect
+        ] = []  # Redirects to return within API response.
+        for redirect in redirects_qs:
             if redirect.site is None:
-                for site in sites_QS:
-                    new_redirect = copy.copy(redirect)
-                    new_redirect.site = site
-                    redirect_list.append(new_redirect)
-
-        redirect_list = filter(lambda x: (x.site is not None), redirect_list)
-
-        return redirect_list
+                # Duplicate Redirect for each Site as it applies to all Sites.
+                for site in Site.objects.all():
+                    _new_redirect = copy.copy(redirect)
+                    _new_redirect.site = site
+                    finalised_redirects.append(_new_redirect)
+            else:
+                finalised_redirects.append(redirect)
+        return finalised_redirects

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,6 +1,8 @@
 from test_grapple import BaseGrappleTest
 from testapp.factories import RedirectFactory
 from testapp.models import BlogPage
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.models import Site
 from wagtail_factories import SiteFactory
 
 
@@ -16,7 +18,8 @@ class TestRedirectQueries(BaseGrappleTest):
         Test that Redirect fields can be queried through graphql.
         """
 
-        self.redirect = RedirectFactory(
+        # Create a basic redirect without a specified `redirect_page` or `site`.
+        RedirectFactory(
             old_path="test/old",
             redirect_link="http://localhost:8000/test/new",
             is_permanent=True,
@@ -36,6 +39,7 @@ class TestRedirectQueries(BaseGrappleTest):
 
         result = self.client.execute(query)
 
+        # Verify that the structure of the results is correct.
         self.assertEqual(type(result["data"]), dict)
         self.assertEqual(type(result["data"]["redirects"]), list)
         self.assertEqual(type(result["data"]["redirects"][0]), dict)
@@ -51,7 +55,8 @@ class TestRedirectQueries(BaseGrappleTest):
         Test that `Page` and `Site` fields on Redirects can be queried through graphql.
         """
 
-        self.redirect = RedirectFactory(
+        # Create a redirect with specified `redirect_page` and `site`.
+        RedirectFactory(
             redirect_page=self.page,
             site=SiteFactory(
                 hostname="test-site",
@@ -76,6 +81,7 @@ class TestRedirectQueries(BaseGrappleTest):
 
         result = self.client.execute(query)
 
+        # Verify the structure of the query for `page` and `site`.
         self.assertEqual(type(result["data"]["redirects"][0]), dict)
         self.assertEqual(type(result["data"]["redirects"][0]["page"]), dict)
         self.assertEqual(type(result["data"]["redirects"][0]["site"]), dict)
@@ -94,17 +100,16 @@ class TestRedirectQueries(BaseGrappleTest):
         When just one is provided, use that.
         """
 
-        self.redirect_both_sources = RedirectFactory(
-            redirect_link="/test/incorrect", redirect_page=self.page
-        )
-        self.redirect_just_page = RedirectFactory(
+        # Create a redirect with both `redirect_link` and `redirect_page`.
+        RedirectFactory(redirect_link="/test/incorrect", redirect_page=self.page)
+        # Create a redirect with just `redirect_page`.
+        RedirectFactory(
             redirect_link="",
             is_permanent=True,
             redirect_page=self.page,
         )
-        self.redirect_just_link = RedirectFactory(
-            redirect_link="http://test/just-link", redirect_page=None
-        )
+        # Create a redirect with just `redirect_link`.
+        RedirectFactory(redirect_link="http://test/just-link", redirect_page=None)
 
         query = """
         {
@@ -116,8 +121,14 @@ class TestRedirectQueries(BaseGrappleTest):
 
         result = self.client.execute(query)["data"]["redirects"]
 
+        # Sanity check to ensure only those three redirect objects are in the database.
+        self.assertEqual(Redirect.objects.count(), 3)
+
+        # Redirects with a specified `redirect_page` should return its url.
         self.assertEqual(result[0]["newUrl"], "http://localhost/test-page-url/")
         self.assertEqual(result[1]["newUrl"], "http://localhost/test-page-url/")
+        # Redirects without a specified `redirect_page` should return the
+        # `redirect_link` instead.
         self.assertEqual(result[2]["newUrl"], "http://test/just-link")
 
     def test_no_new_url_query(self):
@@ -126,7 +137,9 @@ class TestRedirectQueries(BaseGrappleTest):
         `redirect_page` and queried. This can be used for producing a HTTP 410
         for any pages/URLs that are no longer in existence.
         """
-        self.redirect = RedirectFactory(
+
+        # Create a redirect with no source for `new_url` generation.
+        RedirectFactory(
             redirect_link="",
             redirect_page=None,
         )
@@ -147,21 +160,27 @@ class TestRedirectQueries(BaseGrappleTest):
         """
         Test that a redirect with a specified site returns the correct `old_url`.
         """
-        self.redirect = RedirectFactory(
+        # Create a redirect with `site` using port 81, which should result in a
+        # standard `old_url` generation.
+        RedirectFactory(
             old_path="old-path",
             site=SiteFactory(
                 hostname="test-site",
                 port=81,
             ),
         )
-        self.redirect = RedirectFactory(
+        # Create a redirect with `site` using port 80, which should be resolved
+        # to "http" without a specified port in `old_url`.
+        RedirectFactory(
             old_path="old-path",
             site=SiteFactory(
                 hostname="test-site-default-port",
                 port=80,
             ),
         )
-        self.redirect = RedirectFactory(
+        # Create a redirect with `site` using port 443, which should be resolved
+        # to "https" without a specified port in `old_url`.
+        RedirectFactory(
             old_path="old-path",
             site=SiteFactory(
                 hostname="test-site-secure",
@@ -179,6 +198,9 @@ class TestRedirectQueries(BaseGrappleTest):
 
         result = self.client.execute(query)["data"]["redirects"]
 
+        # Sanity check to ensure only those three redirect objects are in the database.
+        self.assertEqual(Redirect.objects.count(), 3)
+
         self.assertEqual(result[0]["oldUrl"], "http://test-site:81/old-path")
         self.assertEqual(result[1]["oldUrl"], "http://test-site-default-port/old-path")
         self.assertEqual(result[2]["oldUrl"], "https://test-site-secure/old-path")
@@ -188,10 +210,13 @@ class TestRedirectQueries(BaseGrappleTest):
         Test that when no site is specified on a redirect, that redirect is
         shown for each existing site.
         """
-        self.site1 = SiteFactory(hostname="test-site", port=81)
-        self.site2 = SiteFactory(hostname="another-test-site", port=82)
 
-        self.redirect = RedirectFactory(
+        # Create two additional sites (on top of the default `Localhost` one).
+        SiteFactory(hostname="test-site", port=81)
+        SiteFactory(hostname="another-test-site", port=82)
+
+        # Create a `Redirect` without a `site` (treated as active for all sites).
+        RedirectFactory(
             old_path="old-path",
             site=None,
         )
@@ -205,6 +230,16 @@ class TestRedirectQueries(BaseGrappleTest):
         """
 
         result = self.client.execute(query)["data"]["redirects"]
+
+        # Sanity check to ensure there are three `Site`s.
+        self.assertEqual(Site.objects.count(), 3)
+
+        # Sanity check to ensure only one `Redirect` is in the database.
+        self.assertEqual(Redirect.objects.count(), 1)
+
+        # Ensure there are three `Redirect`s returned despite only 1 object
+        # in the database.
+        self.assertEqual(len(result), 3)
 
         self.assertEqual(result[0]["oldUrl"], "http://another-test-site:82/old-path")
         self.assertEqual(result[1]["oldUrl"], "http://localhost/old-path")

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -63,7 +63,7 @@ class TestRedirectQueries(BaseGrappleTest):
             redirect_page=self.page,
         )
         self.redirect_just_link = RedirectFactory(
-            redirect_link="/test/just-link", redirect_page=None
+            redirect_link="http://test/just-link", redirect_page=None
         )
 
         query = """
@@ -76,9 +76,9 @@ class TestRedirectQueries(BaseGrappleTest):
 
         result = self.client.execute(query)["data"]["redirects"]
 
-        self.assertEqual(result[0]["newUrl"], "/test-page-url/")
-        self.assertEqual(result[1]["newUrl"], "/test-page-url/")
-        self.assertEqual(result[2]["newUrl"], "/test/just-link")
+        self.assertEqual(result[0]["newUrl"], "http://localhost/test-page-url/")
+        self.assertEqual(result[1]["newUrl"], "http://localhost/test-page-url/")
+        self.assertEqual(result[2]["newUrl"], "http://test/just-link")
 
     def test_no_new_url_query(self):
         """

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,5 +1,3 @@
-import json
-
 from test_grapple import BaseGrappleTest
 from testapp.factories import RedirectFactory
 from testapp.models import BlogPage
@@ -187,11 +185,11 @@ class TestRedirectQueries(BaseGrappleTest):
 
     def test_all_sites_url(self):
         """
-        Test that a redirect with no specified site return the desired result
-        for "all sites".
+        Test that when no site is specified on a redirect, that redirect is
+        shown for each existing site.
         """
-        self.site1 = SiteFactory(hostname="test-site", port=8000)
-        self.site2 = SiteFactory(hostname="another-test-site", port=8001)
+        self.site1 = SiteFactory(hostname="test-site", port=81)
+        self.site2 = SiteFactory(hostname="another-test-site", port=82)
 
         self.redirect = RedirectFactory(
             old_path="old-path",
@@ -206,9 +204,8 @@ class TestRedirectQueries(BaseGrappleTest):
         }
         """
 
-        result = self.client.execute(query)["data"]["redirects"][0]["oldUrl"]
-        result = json.loads(result)
+        result = self.client.execute(query)["data"]["redirects"]
 
-        self.assertIn("http://localhost:80/old-path", result)
-        self.assertIn("http://test-site:8000/old-path", result)
-        self.assertIn("http://another-test-site:8001/old-path", result)
+        self.assertEqual(result[0]["oldUrl"], "http://another-test-site:82/old-path")
+        self.assertEqual(result[1]["oldUrl"], "http://localhost/old-path")
+        self.assertEqual(result[2]["oldUrl"], "http://test-site:81/old-path")

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -20,7 +20,7 @@ class TestRedirectQueries(BaseGrappleTest):
 
         # Create a basic redirect without a specified `redirect_page` or `site`.
         RedirectFactory(
-            old_path="test/old",
+            old_path="/test/old",
             redirect_link="http://localhost:8000/test/new",
             is_permanent=True,
             redirect_page=None,
@@ -46,7 +46,7 @@ class TestRedirectQueries(BaseGrappleTest):
 
         result_data = result["data"]["redirects"][0]
 
-        self.assertEqual(result_data["oldPath"], "test/old")
+        self.assertEqual(result_data["oldPath"], "/test/old")
         self.assertEqual(result_data["newUrl"], "http://localhost:8000/test/new")
         self.assertEqual(result_data["isPermanent"], True)
 

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,0 +1,102 @@
+from test_grapple import BaseGrappleTest
+from testapp.factories import RedirectFactory
+from testapp.models import BlogPage
+
+
+class TestRedirectQueries(BaseGrappleTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.page = BlogPage(title="Test page", slug="test-page-url", date="2020-01-01")
+        self.home.add_child(instance=self.page)
+
+    def test_basic_query(self):
+        """
+        Test that Redirect fields can be queried through graphql.
+        """
+
+        self.redirect = RedirectFactory(
+            old_path="/test/old",
+            redirect_link="http://localhost:8000/test/new",
+            is_permanent=True,
+            redirect_page=None,
+        )
+
+        query = """
+        {
+            redirects {
+                oldPath
+                oldUrl
+                newUrl
+                isPermanent
+            }
+        }
+        """
+
+        result = self.client.execute(query)
+
+        self.assertEqual(type(result["data"]), dict)
+        self.assertEqual(type(result["data"]["redirects"]), list)
+        self.assertEqual(type(result["data"]["redirects"][0]), dict)
+
+        result_data = result["data"]["redirects"][0]
+
+        self.assertEqual(result_data["oldPath"], "/test/old")
+        self.assertEqual(result_data["oldUrl"], "http://localhost:8000/test/old")
+        self.assertEqual(result_data["newUrl"], "http://localhost:8000/test/new")
+        self.assertEqual(result_data["isPermanent"], True)
+
+    def test_new_url_sources(self):
+        """
+        Test that when redirects are queried, the right source for `newUrl` is chosen.
+        When both are provided: `newUrl` is taken from `redirect page` rather than `redirect link`.
+        When just one is provided, use that.
+        """
+
+        self.redirect_both_sources = RedirectFactory(
+            redirect_link="/test/incorrect", redirect_page=self.page
+        )
+        self.redirect_just_page = RedirectFactory(
+            redirect_link="",
+            is_permanent=True,
+            redirect_page=self.page,
+        )
+        self.redirect_just_link = RedirectFactory(
+            redirect_link="/test/just-link", redirect_page=None
+        )
+
+        query = """
+        {
+            redirects {
+                newUrl
+            }
+        }
+        """
+
+        result = self.client.execute(query)["data"]["redirects"]
+
+        self.assertEqual(result[0]["newUrl"], "/test-page-url/")
+        self.assertEqual(result[1]["newUrl"], "/test-page-url/")
+        self.assertEqual(result[2]["newUrl"], "/test/just-link")
+
+    def test_no_new_url_query(self):
+        """
+        Test that a redirect can be created without a `redirect_link` or
+        `redirect_page` and queried. This can be used for producing a HTTP 410
+        for any pages/URLs that are no longer in existence.
+        """
+        self.redirect = RedirectFactory(
+            redirect_link="",
+            redirect_page=None,
+        )
+
+        query = """
+        {
+            redirects {
+                newUrl
+            }
+        }
+        """
+
+        result = self.client.execute(query)["data"]["redirects"][0]["newUrl"]
+
+        self.assertEqual(result, None)

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -186,7 +186,8 @@ class MiddlewareModelFactory(factory.django.DjangoModelFactory):
 
 class RedirectFactory(factory.django.DjangoModelFactory):
     """
-    TODO: Consider moving to wagtail factories?
+    TODO: Replace with RedirectFactory from wagtail-factories once it exists
+    @see https://github.com/wagtail/wagtail-factories/issues/82
     """
 
     old_path = factory.Faker("slug")
@@ -201,8 +202,9 @@ class RedirectFactory(factory.django.DjangoModelFactory):
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
         """
-        Override _create() to ensure that Redirect.clean() is run
-        in order to normalise `old_path`.
+        Override _create() to ensure that Redirect.clean() is run in order to
+        normalise `old_path`.
+        @see https://github.com/wagtail/wagtail/blob/main/wagtail/contrib/redirects/models.py#L191
         """
         obj = model_class(*args, **kwargs)
         try:

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -185,6 +185,10 @@ class MiddlewareModelFactory(factory.django.DjangoModelFactory):
 
 
 class RedirectFactory(factory.django.DjangoModelFactory):
+    """
+    TODO: Consider moving to wagtail factories?
+    """
+
     old_path = factory.Faker("slug")
     # Note: Site needs `hostname` and `port` to be a unique combination,
     # so this seems like the best option:

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -6,7 +6,6 @@ import wagtail_factories
 from factory import fuzzy
 from wagtail import blocks
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.models import Site
 
 from testapp.blocks import (
     CustomInterfaceBlock,
@@ -190,9 +189,7 @@ class RedirectFactory(factory.django.DjangoModelFactory):
     """
 
     old_path = factory.Faker("slug")
-    # Note: Site needs `hostname` and `port` to be a unique combination,
-    # so this seems like the best option:
-    site = factory.Iterator(Site.objects.all())
+    site = factory.SubFactory(wagtail_factories.SiteFactory)
     redirect_page = factory.SubFactory(wagtail_factories.PageFactory)
     redirect_link = factory.Faker("url")
     is_permanent = factory.Faker("boolean")

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -5,6 +5,8 @@ import wagtail_factories
 
 from factory import fuzzy
 from wagtail import blocks
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.models import Site
 
 from testapp.blocks import (
     CustomInterfaceBlock,
@@ -180,3 +182,16 @@ class SimpleModelFactory(factory.django.DjangoModelFactory):
 class MiddlewareModelFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = MiddlewareModel
+
+
+class RedirectFactory(factory.django.DjangoModelFactory):
+    old_path = factory.Faker("slug")
+    # Note: Site needs `hostname` and `port` to be a unique combination,
+    # so this seems like the best option:
+    site = factory.Iterator(Site.objects.all())
+    redirect_page = factory.SubFactory(wagtail_factories.PageFactory)
+    redirect_link = factory.Faker("url")
+    is_permanent = factory.Faker("boolean")
+
+    class Meta:
+        model = Redirect


### PR DESCRIPTION
This PR changes `old_url` handling in `RedirectType` to replace hardcoded URL generation with dynamically generated URLs based on wagtail's `sites` properties.

Additionally:

- Fixes issue where query would fail if `Redirect` had no specified target.
- Introduces general test suite for redirects.

The changes were tested for performance and did not increase the number of queries when querying `Redirects`.