### PR TITLE
Default to the original SVG rendition if none of the filters are SVG-safe

### DIFF
--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -146,6 +146,9 @@ class ImageObjectType(DjangoObjectType):
         if instance.is_svg() and preserve_svg:
             # when dealing with SVGs, we want to limit the filter specs to those that are safe
             filter_specs = to_svg_safe_spec(filter_specs)
+            if not filter_specs:
+                # if there are no valid filters, fall back to the original
+                filter_specs = "original"
 
             if not filter_specs:
                 raise TypeError(

--- a/tests/test_image_types.py
+++ b/tests/test_image_types.py
@@ -302,7 +302,9 @@ class ImageTypesTestWithSVG(BaseGrappleTestWithIntrospection):
             query, variables={"id": self.example_svg_image.id}
         )
         self.assertTrue(
-            results["data"]["image"]["rendition"]["url"].endswith("test.width-150.svg")
+            results["data"]["image"]["rendition"]["url"].endswith(
+                "grapple-test.width-150.svg"
+            )
         )
 
     def test_svg_src_set_with_raster_format_with_preserve_svg(self):
@@ -318,7 +320,9 @@ class ImageTypesTestWithSVG(BaseGrappleTestWithIntrospection):
             query, variables={"id": self.example_svg_image.id}
         )
         self.assertTrue(
-            results["data"]["image"]["srcSet"].split()[0].endswith("test.width-100.svg")
+            results["data"]["image"]["srcSet"]
+            .split()[0]
+            .endswith("grapple-test.width-100.svg")
         )
 
     def test_svg_rendition_with_raster_format_without_preserve_svg(self):
@@ -372,8 +376,8 @@ class ImageTypesTestWithSVG(BaseGrappleTestWithIntrospection):
         results = self.client.execute(
             query, variables={"id": self.example_svg_image.id}
         )
-        self.assertIsNone(results["data"]["image"]["rendition"])
-        self.assertEqual(
-            results["errors"][0]["message"],
-            "No valid filter specs for SVG. See https://docs.wagtail.org/en/stable/topics/images.html#svg-images for details.",
+        self.assertTrue(
+            results["data"]["image"]["rendition"]["url"].endswith(
+                "grapple-test.original.svg"
+            )
         )

--- a/tests/test_image_types.py
+++ b/tests/test_image_types.py
@@ -1,11 +1,9 @@
-from unittest import skipIf
-
 import wagtail_factories
 
 from django.test import override_settings
 from test_grapple import BaseGrappleTestWithIntrospection
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file_svg
 
 from grapple.types.images import rendition_allowed
 
@@ -152,34 +150,7 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
         self.assertIn("width-100.format-webp.webp", data["srcSet"])
         self.assertIn("width-300.format-webp.webp", data["srcSet"])
 
-    @skipIf(
-        WAGTAIL_VERSION >= (5, 2),
-        "Exception message is different in Wagtail 5.2+",
-    )
-    def test_src_set_invalid_format_wagtail_below_5_2(self):
-        """
-        Ensure that an exception is raised when image format is not of valid type.
-        Works with Wagtail versions below 5.2. For versions 5.2 and above see:
-        `test_src_set_invalid_format_wagtail_above_5_2`.
-        """
-
-        query = """
-        query ($id: ID!) {
-            image(id: $id) {
-                srcSet(sizes: [100, 300], format: "foobar")
-            }
-        }
-        """
-
-        results = self.client.execute(query, variables={"id": self.example_image.id})
-        self.assertEqual(len(results["errors"]), 1)
-        self.assertIn("Format must be either 'jpeg'", results["errors"][0]["message"])
-
-    @skipIf(
-        WAGTAIL_VERSION < (5, 2),
-        "Exception message is different in Wagtail verions below 5.2",
-    )
-    def test_src_set_invalid_format_wagtail_above_5_2(self):
+    def test_src_set_invalid_format(self):
         """
         Ensure that an exception is raised when image format is not of valid type.
         Works with Wagtail versions 5.2 and above. For versions below 5.2 see:
@@ -256,7 +227,25 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
         with self.assertNumQueries(2):
             self.client.execute(query)
 
-    @skipIf(WAGTAIL_VERSION >= (5, 0), "SVG support added in Wagtail 5.0")
+
+class ImageTypesTestWithSVG(BaseGrappleTestWithIntrospection):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.example_svg_image = wagtail_factories.ImageFactory(
+            title="Example SVG Image",
+            file=get_test_image_file_svg(filename="grapple-test.svg"),
+        )
+
+    def tearDown(self) -> None:
+        for rendition in self.example_svg_image.renditions.all():
+            rendition.file.delete(save=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.example_svg_image.file.delete(save=False)
+
     def test_schema_for_svg_related_fields_and_arguments(self):
         results = self.introspect_schema_by_type(Image.__name__)
         mapping = {
@@ -265,164 +254,126 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
         rendition_args = {arg["name"]: arg for arg in mapping["rendition"]["args"]}
         src_set_args = {arg["name"]: arg for arg in mapping["srcSet"]["args"]}
 
-        self.assertNotIn("isSvg", mapping)
-        self.assertNotIn("preserveSvg", rendition_args)
-        self.assertNotIn("preserveSvg", src_set_args)
+        self.assertIn("isSvg", mapping)
+        self.assertEqual(mapping["isSvg"]["type"]["kind"], "NON_NULL")
+        self.assertEqual(rendition_args["preserveSvg"]["type"]["name"], "Boolean")
+        self.assertEqual(
+            rendition_args["preserveSvg"]["description"],
+            "Prevents raster image operations (e.g. `format-webp`, `bgcolor`, etc.) being applied to SVGs. "
+            "More info: https://docs.wagtail.org/en/stable/topics/images.html#svg-images",
+        )
+        self.assertEqual(src_set_args["preserveSvg"]["type"]["name"], "Boolean")
+        self.assertEqual(
+            src_set_args["preserveSvg"]["description"],
+            "Prevents raster image operations (e.g. `format-webp`, `bgcolor`, etc.) being applied to SVGs. "
+            "More info: https://docs.wagtail.org/en/stable/topics/images.html#svg-images",
+        )
 
-
-if WAGTAIL_VERSION >= (5, 0):
-    from wagtail.images.tests.utils import get_test_image_file_svg
-
-    class ImageTypesTestWithSVG(BaseGrappleTestWithIntrospection):
-        @classmethod
-        def setUpTestData(cls):
-            super().setUpTestData()
-            cls.example_svg_image = wagtail_factories.ImageFactory(
-                title="Example SVG Image",
-                file=get_test_image_file_svg(filename="grapple-test.svg"),
-            )
-
-        def tearDown(self) -> None:
-            for rendition in self.example_svg_image.renditions.all():
-                rendition.file.delete(save=False)
-
-        @classmethod
-        def tearDownClass(cls):
-            super().tearDownClass()
-            cls.example_svg_image.file.delete(save=False)
-
-        def test_schema_for_svg_related_fields_and_arguments(self):
-            results = self.introspect_schema_by_type(Image.__name__)
-            mapping = {
-                field["name"]: field for field in results["data"]["__type"]["fields"]
-            }
-            rendition_args = {arg["name"]: arg for arg in mapping["rendition"]["args"]}
-            src_set_args = {arg["name"]: arg for arg in mapping["srcSet"]["args"]}
-
-            self.assertIn("isSvg", mapping)
-            self.assertEqual(mapping["isSvg"]["type"]["kind"], "NON_NULL")
-            self.assertEqual(rendition_args["preserveSvg"]["type"]["name"], "Boolean")
-            self.assertEqual(
-                rendition_args["preserveSvg"]["description"],
-                "Prevents raster image operations (e.g. `format-webp`, `bgcolor`, etc.) being applied to SVGs. "
-                "More info: https://docs.wagtail.org/en/stable/topics/images.html#svg-images",
-            )
-            self.assertEqual(src_set_args["preserveSvg"]["type"]["name"], "Boolean")
-            self.assertEqual(
-                src_set_args["preserveSvg"]["description"],
-                "Prevents raster image operations (e.g. `format-webp`, `bgcolor`, etc.) being applied to SVGs. "
-                "More info: https://docs.wagtail.org/en/stable/topics/images.html#svg-images",
-            )
-
-        def test_svg_rendition(self):
-            query = """
-            query ($id: ID!) {
-                image(id: $id) {
-                    isSvg
-                    rendition(width: 100) {
-                        url
-                    }
+    def test_svg_rendition(self):
+        query = """
+        query ($id: ID!) {
+            image(id: $id) {
+                isSvg
+                rendition(width: 100) {
+                    url
                 }
             }
-            """
+        }
+        """
 
-            data = self.client.execute(
-                query, variables={"id": self.example_svg_image.id}
-            )["data"]["image"]
-            self.assertTrue(data["isSvg"])
-            self.assertTrue(data["rendition"]["url"].endswith("test.width-100.svg"))
+        data = self.client.execute(query, variables={"id": self.example_svg_image.id})[
+            "data"
+        ]["image"]
+        self.assertTrue(data["isSvg"])
+        self.assertTrue(data["rendition"]["url"].endswith("test.width-100.svg"))
 
-        def test_svg_rendition_with_raster_format_with_preserve_svg(self):
-            query = """
-            query ($id: ID!) {
-                image(id: $id) {
-                    rendition(width: 150, format: "webp") {
-                        url
-                    }
+    def test_svg_rendition_with_raster_format_with_preserve_svg(self):
+        query = """
+        query ($id: ID!) {
+            image(id: $id) {
+                rendition(width: 150, format: "webp") {
+                    url
                 }
             }
-            """
+        }
+        """
 
-            results = self.client.execute(
-                query, variables={"id": self.example_svg_image.id}
-            )
-            self.assertTrue(
-                results["data"]["image"]["rendition"]["url"].endswith(
-                    "test.width-150.svg"
-                )
-            )
+        results = self.client.execute(
+            query, variables={"id": self.example_svg_image.id}
+        )
+        self.assertTrue(
+            results["data"]["image"]["rendition"]["url"].endswith("test.width-150.svg")
+        )
 
-        def test_svg_src_set_with_raster_format_with_preserve_svg(self):
-            query = """
-            query ($id: ID!) {
-                image(id: $id) {
-                    srcSet(sizes: [100], format: "webp")
+    def test_svg_src_set_with_raster_format_with_preserve_svg(self):
+        query = """
+        query ($id: ID!) {
+            image(id: $id) {
+                srcSet(sizes: [100], format: "webp")
+            }
+        }
+        """
+
+        results = self.client.execute(
+            query, variables={"id": self.example_svg_image.id}
+        )
+        self.assertTrue(
+            results["data"]["image"]["srcSet"].split()[0].endswith("test.width-100.svg")
+        )
+
+    def test_svg_rendition_with_raster_format_without_preserve_svg(self):
+        query = """
+        query ($id: ID!) {
+            image(id: $id) {
+                rendition(width: 200, format: "webp", preserveSvg: false) {
+                    url
                 }
             }
-            """
+        }
+        """
 
-            results = self.client.execute(
-                query, variables={"id": self.example_svg_image.id}
-            )
-            self.assertTrue(
-                results["data"]["image"]["srcSet"]
-                .split()[0]
-                .endswith("test.width-100.svg")
-            )
+        results = self.client.execute(
+            query, variables={"id": self.example_svg_image.id}
+        )
+        self.assertEqual(
+            results["errors"][0]["message"],
+            "'SvgImage' object has no attribute 'save_as_webp'",
+        )
 
-        def test_svg_rendition_with_raster_format_without_preserve_svg(self):
-            query = """
-            query ($id: ID!) {
-                image(id: $id) {
-                    rendition(width: 200, format: "webp", preserveSvg: false) {
-                        url
-                    }
+    def test_svg_src_set_with_raster_format_without_preserve_svg(self):
+        query = """
+        query ($id: ID!) {
+            image(id: $id) {
+                srcSet(sizes: [100], format: "webp", preserveSvg: false)
+            }
+        }
+        """
+
+        results = self.client.execute(
+            query, variables={"id": self.example_svg_image.id}
+        )
+        self.assertEqual(
+            results["errors"][0]["message"],
+            "'SvgImage' object has no attribute 'save_as_webp'",
+        )
+
+    def test_svg_rendition_with_filters_passed_through_to_svg_safe_spec(self):
+        # bgcolor is not one of the allowed filters, so we should end with an empty filter spec
+        query = """
+        query ($id: ID!) {
+            image(id: $id) {
+                rendition(bgcolor: "fff", format: "webp") {
+                    url
                 }
             }
-            """
+        }
+        """
 
-            results = self.client.execute(
-                query, variables={"id": self.example_svg_image.id}
-            )
-            self.assertEqual(
-                results["errors"][0]["message"],
-                "'SvgImage' object has no attribute 'save_as_webp'",
-            )
-
-        def test_svg_src_set_with_raster_format_without_preserve_svg(self):
-            query = """
-            query ($id: ID!) {
-                image(id: $id) {
-                    srcSet(sizes: [100], format: "webp", preserveSvg: false)
-                }
-            }
-            """
-
-            results = self.client.execute(
-                query, variables={"id": self.example_svg_image.id}
-            )
-            self.assertEqual(
-                results["errors"][0]["message"],
-                "'SvgImage' object has no attribute 'save_as_webp'",
-            )
-
-        def test_svg_rendition_with_filters_passed_through_to_svg_safe_spec(self):
-            # bgcolor is not one of the allowed filters, so we should end with an empty filter spec
-            query = """
-            query ($id: ID!) {
-                image(id: $id) {
-                    rendition(bgcolor: "fff", format: "webp") {
-                        url
-                    }
-                }
-            }
-            """
-
-            results = self.client.execute(
-                query, variables={"id": self.example_svg_image.id}
-            )
-            self.assertIsNone(results["data"]["image"]["rendition"])
-            self.assertEqual(
-                results["errors"][0]["message"],
-                "No valid filter specs for SVG. See https://docs.wagtail.org/en/stable/topics/images.html#svg-images for details.",
-            )
+        results = self.client.execute(
+            query, variables={"id": self.example_svg_image.id}
+        )
+        self.assertIsNone(results["data"]["image"]["rendition"])
+        self.assertEqual(
+            results["errors"][0]["message"],
+            "No valid filter specs for SVG. See https://docs.wagtail.org/en/stable/topics/images.html#svg-images for details.",
+        )


### PR DESCRIPTION
Fixes #389

also removes a bunch of pre Wagtail 5.2 conditional code.

cc @jams2 