### PR TITLE
Ensure `new_url` is absolute in Redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Changed
+- Handling of `new_url` on `RedirectObjectType` to always return absolute URLs ([#380](https://github.com/torchbox/wagtail-grapple/pull/391)) @JakubMastalerz
+
 ## [0.25.1] - 2024-04-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Changed
-- Handling of `new_url` on `RedirectObjectType` to always return absolute URLs ([#380](https://github.com/torchbox/wagtail-grapple/pull/391)) @JakubMastalerz
+- Handling of `new_url` on `RedirectObjectType` to always return absolute URLs ([#391](https://github.com/torchbox/wagtail-grapple/pull/391)) @JakubMastalerz
 
 ## [0.25.1] - 2024-04-21
 

--- a/grapple/settings.py
+++ b/grapple/settings.py
@@ -72,7 +72,7 @@ class GrappleSettings:
 
     def __getattr__(self, attr):
         if attr not in self.defaults:
-            raise AttributeError("Invalid Grapple setting: '%s'" % attr)
+            raise AttributeError(f"Invalid Grapple setting: '{attr}'")
 
         try:
             # Check if present in user settings

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -26,7 +26,7 @@ class RedirectObjectType(graphene.ObjectType):
     class Meta:
         name = "Redirect"
 
-    def resolve_old_url(self, info, **kwargs) -> str:
+    def resolve_old_url(self: Redirect, info, **kwargs) -> str:
         """
         Resolve the value of `old_url` using the `root_url` of the associated
         site and `old_path`.
@@ -34,7 +34,7 @@ class RedirectObjectType(graphene.ObjectType):
 
         return self.site.root_url + self.old_path
 
-    def resolve_new_url(self, info, **kwargs) -> Optional[str]:
+    def resolve_new_url(self: Redirect, info, **kwargs) -> Optional[str]:
         """
         Resolve the value of `new_url`. If `redirect_page` is specified then
         `link` is used. Otherwise, ensure that the redirect link is absolute.
@@ -58,7 +58,7 @@ class RedirectObjectType(graphene.ObjectType):
             return None
 
     # Return the page that's being redirected to, if at all.
-    def resolve_page(self, info, **kwargs) -> Optional[Page]:
+    def resolve_page(self: Redirect, info, **kwargs) -> Optional[Page]:
         if self.redirect_page is not None:
             return self.redirect_page.specific
 

--- a/tests/test_image_types.py
+++ b/tests/test_image_types.py
@@ -90,18 +90,15 @@ class ImageTypesTest(BaseGrappleTestWithIntrospection):
     def test_renditions_with_allowed_image_filters_restrictions(self):
         def get_query(**kwargs):
             params = ",".join([f"{key}: {value}" for key, value in kwargs.items()])
-            return (
-                """
-            query ($id: ID!) {
-                image(id: $id) {
-                    rendition(%s) {
-                        url
-                    }
-                }
-            }
-            """
-                % params
-            )
+            return f"""
+                    query ($id: ID!) {{
+                        image(id: $id) {{
+                            rendition({params}) {{
+                                url
+                            }}
+                        }}
+                    }}
+                    """
 
         results = self.client.execute(
             get_query(width=100), variables={"id": self.example_image.id}


### PR DESCRIPTION
resolves #384 

This PR changes `new_url` handling in `RedirectType` to ensure that the returned value is always an absolute URL. 

In `resolve_new_url`, instead of relying entirely on the `link` property of the `Redirect` model, a check was added to ensure the URL being passed is absolute when the redirect does not point to a specific `Page` object. Relative URLs will be turned into absolute URLs. 