### PR TITLE
Make StreamfieldChooser blocks values nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+-   Make value fields nullable on `PageChooserBlock`, `SnippetChooserBlock`, `DocumentChooserBlock` and `ImageChooserBlock`
+
 ## [0.25.1] - 2024-04-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
--   Make value fields nullable on `PageChooserBlock`, `SnippetChooserBlock`, `DocumentChooserBlock` and `ImageChooserBlock`
+-   Make value fields nullable on `PageChooserBlock`, `SnippetChooserBlock`, `DocumentChooserBlock` and `ImageChooserBlock` ([#396](https://github.com/torchbox/wagtail-grapple/pull/396))
 
 ## [0.25.1] - 2024-04-21
 

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -436,7 +436,7 @@ def register_streamfield_blocks():
     from .snippets import SnippetTypes
 
     class PageChooserBlock(graphene.ObjectType):
-        page = graphene.Field(get_page_interface(), required=True)
+        page = graphene.Field(get_page_interface(), required=False)
 
         class Meta:
             interfaces = (StreamFieldInterface,)
@@ -445,7 +445,7 @@ def register_streamfield_blocks():
             return self.value.specific
 
     class DocumentChooserBlock(graphene.ObjectType):
-        document = graphene.Field(get_document_type(), required=True)
+        document = graphene.Field(get_document_type(), required=False)
 
         class Meta:
             interfaces = (StreamFieldInterface,)
@@ -454,7 +454,7 @@ def register_streamfield_blocks():
             return self.value
 
     class ImageChooserBlock(graphene.ObjectType):
-        image = graphene.Field(get_image_type(), required=True)
+        image = graphene.Field(get_image_type(), required=False)
 
         class Meta:
             interfaces = (StreamFieldInterface,)
@@ -474,7 +474,7 @@ def register_streamfield_blocks():
     if SnippetObjectType is not None:
 
         class SnippetChooserBlock(graphene.ObjectType):
-            snippet = graphene.Field(SnippetObjectType, required=True)
+            snippet = graphene.Field(SnippetObjectType, required=False)
 
             class Meta:
                 interfaces = (StreamFieldInterface,)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -80,7 +80,7 @@ class InterfacesTestCase(BaseGrappleTestWithIntrospection):
             [{"name": "CustomInterface"}, {"name": "PageInterface"}],
         )
 
-    def test_schem_for_snippet_with_graphql_interface(self):
+    def test_schema_for_snippet_with_graphql_interface(self):
         results = self.introspect_schema_by_type("Advert")
         self.assertListEqual(
             sorted(results["data"]["__type"]["interfaces"], key=lambda x: x["name"]),

--- a/tests/test_models_types.py
+++ b/tests/test_models_types.py
@@ -1,7 +1,12 @@
 import graphene
 
 from django.test import TestCase
+from wagtail.blocks.field_block import PageChooserBlock
+from wagtail.documents.blocks import DocumentChooserBlock
+from wagtail.images.blocks import ImageChooserBlock
+from wagtail.snippets.blocks import SnippetChooserBlock
 
+from grapple import registry
 from grapple.actions import get_field_type
 from grapple.exceptions import IllegalDeprecation
 from grapple.models import (
@@ -183,3 +188,54 @@ class FieldTest(TestCase):
                 required=True,
                 deprecation_reason=self.deprecation_reason,
             )()
+
+
+class ChooserBlocksTest(TestCase):
+    """
+    Test that "Chooser" blocks take null values to ensure correct handling
+    of deleted objects referenced in these blocks.
+    """
+
+    def test_snippet_chooser_block_value_field_not_required(self):
+        """
+        Test the SnippetChooserBlock snippet field.
+        """
+        block = registry.registry.streamfield_blocks[SnippetChooserBlock]
+        field = block.snippet
+
+        # Check that field is not required by asserting type isn't `NonNull`
+        self.assertIsInstance(field, graphene.types.field.Field)
+        self.assertNotIsInstance(field, graphene.NonNull)
+
+    def test_document_chooser_block_value_field_not_required(self):
+        """
+        Test the DocumentChooserBlock document field.
+        """
+        block = registry.registry.streamfield_blocks[DocumentChooserBlock]
+        field = block.document
+
+        # Check that field is not required by asserting type isn't `NonNull`
+        self.assertIsInstance(field, graphene.types.field.Field)
+        self.assertNotIsInstance(field, graphene.NonNull)
+
+    def test_image_chooser_block_value_field_not_required(self):
+        """
+        Test the ImageChooserBlock image field.
+        """
+        block = registry.registry.streamfield_blocks[ImageChooserBlock]
+        field = block.image
+
+        # Check that field is not required by asserting type isn't `NonNull`
+        self.assertIsInstance(field, graphene.types.field.Field)
+        self.assertNotIsInstance(field, graphene.NonNull)
+
+    def test_page_chooser_block_value_field_not_required(self):
+        """
+        Test the PageChooserBlock page field.
+        """
+        block = registry.registry.streamfield_blocks[PageChooserBlock]
+        field = block.page
+
+        # Check that field is not required by asserting type isn't `NonNull`
+        self.assertIsInstance(field, graphene.types.field.Field)
+        self.assertNotIsInstance(field, graphene.NonNull)

--- a/tests/test_models_types.py
+++ b/tests/test_models_types.py
@@ -205,7 +205,7 @@ class ChooserBlocksTest(TestCase):
 
         # Check that field is not required by asserting type isn't `NonNull`
         self.assertIsInstance(field, graphene.types.field.Field)
-        self.assertNotIsInstance(field, graphene.NonNull)
+        self.assertNotIsInstance(field.type, graphene.NonNull)
 
     def test_document_chooser_block_value_field_not_required(self):
         """
@@ -216,7 +216,7 @@ class ChooserBlocksTest(TestCase):
 
         # Check that field is not required by asserting type isn't `NonNull`
         self.assertIsInstance(field, graphene.types.field.Field)
-        self.assertNotIsInstance(field, graphene.NonNull)
+        self.assertNotIsInstance(field.type, graphene.NonNull)
 
     def test_image_chooser_block_value_field_not_required(self):
         """
@@ -227,7 +227,7 @@ class ChooserBlocksTest(TestCase):
 
         # Check that field is not required by asserting type isn't `NonNull`
         self.assertIsInstance(field, graphene.types.field.Field)
-        self.assertNotIsInstance(field, graphene.NonNull)
+        self.assertNotIsInstance(field.type, graphene.NonNull)
 
     def test_page_chooser_block_value_field_not_required(self):
         """
@@ -238,4 +238,4 @@ class ChooserBlocksTest(TestCase):
 
         # Check that field is not required by asserting type isn't `NonNull`
         self.assertIsInstance(field, graphene.types.field.Field)
-        self.assertNotIsInstance(field, graphene.NonNull)
+        self.assertNotIsInstance(field.type, graphene.NonNull)

--- a/tests/test_models_types.py
+++ b/tests/test_models_types.py
@@ -198,7 +198,8 @@ class ChooserBlocksTest(TestCase):
 
     def test_snippet_chooser_block_value_field_not_required(self):
         """
-        Test the SnippetChooserBlock snippet field.
+        Test that the SnippetChooserBlock snippet field is nullable in the
+        GraphQL schema.
         """
         block = registry.registry.streamfield_blocks[SnippetChooserBlock]
         field = block.snippet
@@ -209,7 +210,8 @@ class ChooserBlocksTest(TestCase):
 
     def test_document_chooser_block_value_field_not_required(self):
         """
-        Test the DocumentChooserBlock document field.
+        Test that the DocumentChooserBlock document field is nullable in the
+        GraphQL schema.
         """
         block = registry.registry.streamfield_blocks[DocumentChooserBlock]
         field = block.document
@@ -220,7 +222,8 @@ class ChooserBlocksTest(TestCase):
 
     def test_image_chooser_block_value_field_not_required(self):
         """
-        Test the ImageChooserBlock image field.
+        Test that the ImageChooserBlock image field is nullable in the GraphQL
+        schema.
         """
         block = registry.registry.streamfield_blocks[ImageChooserBlock]
         field = block.image
@@ -231,7 +234,8 @@ class ChooserBlocksTest(TestCase):
 
     def test_page_chooser_block_value_field_not_required(self):
         """
-        Test the PageChooserBlock page field.
+        Test that the PageChooserBlock page field is nullable in the GraphQL
+        schema.
         """
         block = registry.registry.streamfield_blocks[PageChooserBlock]
         field = block.page


### PR DESCRIPTION
resolves #394 

This PR changes the "value fields" of `SnippetChooserBlock`, `DocumentChooserBlock`, `ImageChooserBlock` and `PageChooserBlock` grapple types to be nullable.

This will allow those blocks to handle referencing deleted objects. Users will be able to implement gracious failing where those blocks are used instead of having to handle grapple errors.