### PR TITLE
Fix issue with querying value on EmbedBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+-   `value` not being queryable on `EmbedBlock` ([#399](https://github.com/torchbox/wagtail-grapple/pull/399))@JakubMastalerz
+
 ## [0.26.0] - 2024-06-26
 
 ### Changed
@@ -23,7 +27,6 @@
 
 -   Support for Django < 4.2, Wagtail < 5.2
 
-
 ## [0.24.0] - 2024-01-05
 
 ### Changed
@@ -35,8 +38,7 @@
 
 ### Fixed
 
-- `test_src_set_invalid_format` not working with Wagtail 5.2 and above. ([#378](https://github.com/torchbox/wagtail-grapple/pull/378)) @JakubMastalerz
-
+-   `test_src_set_invalid_format` not working with Wagtail 5.2 and above. ([#378](https://github.com/torchbox/wagtail-grapple/pull/378)) @JakubMastalerz
 
 ## [0.23.0] - 2023-09-29
 
@@ -49,7 +51,6 @@
 -   `preserveSVG` is true by default ([#371](https://github.com/torchbox/wagtail-grapple/pull/371)) @mgax
 -   Improvements to the CI pipelines
 
-
 ## [0.22.0] - 2023-09-18
 
 ### Added
@@ -57,7 +58,6 @@
 -   Add global mechanism for overriding the base `PageInterface` ([#325](https://github.com/torchbox/wagtail-grapple/pull/325)) @Leden, @dopry, @zerolab
 -   Allow defining additional interfaces via `graphql_interfaces` ([#366](https://github.com/torchbox/wagtail-grapple/pull/366)) @mgax, @zerolab
     This applies to all models, including StreamField blocks
-
 
 ## [0.21.0] - 2023-09-04
 
@@ -74,10 +74,9 @@
 -   Pass the `GraphQLResolveInfo` object to the StreamField callables ([#356](https://github.com/torchbox/wagtail-grapple/pull/356)) @zerolab
     This is passed as the `info` kwarg.
 -   The image rendition query will now surface any errors when:
-  -   using filters not present in the `ALLOWED_IMAGE_FILTERS` Grapple setting,
-  -   there are no filters to apply (for example you are requesting an SVG rendition but supply raster image operations)
-  -   the source image is not present
-
+-   using filters not present in the `ALLOWED_IMAGE_FILTERS` Grapple setting,
+-   there are no filters to apply (for example you are requesting an SVG rendition but supply raster image operations)
+-   the source image is not present
 
 ## [0.20.0] - 2023-07-10
 

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -363,6 +363,11 @@ class EmbedBlock(graphene.ObjectType):
             return self
         return StreamFieldInterface.resolve_raw_value(info, **kwargs)
 
+    def resolve_raw_value(self, info, **kwargs):
+        if isinstance(self, EmbedValue):
+            return self
+        return StreamFieldInterface.resolve_raw_value(info, **kwargs)
+
     def resolve_embed(self, info, **kwargs):
         embed = get_embed_object(self)
         if embed:

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -1,5 +1,7 @@
 import inspect
 
+from typing import Optional
+
 import graphene
 
 # TODO: use specific imports
@@ -355,25 +357,23 @@ class EmbedBlock(graphene.ObjectType):
     class Meta:
         interfaces = (StreamFieldInterface,)
 
-    def resolve_url(self, info, **kwargs):
+    def resolve_url(self: EmbedValue, info, **kwargs) -> str:
         return get_embed_url(self)
 
-    def resolve_value(self, info, **kwargs):
+    def resolve_raw_value(self: EmbedValue, info, **kwargs) -> str:
         if isinstance(self, EmbedValue):
             return self
         return StreamFieldInterface.resolve_raw_value(info, **kwargs)
 
-    def resolve_raw_value(self, info, **kwargs):
-        if isinstance(self, EmbedValue):
-            return self
-        return StreamFieldInterface.resolve_raw_value(info, **kwargs)
+    def resolve_value(self: EmbedValue, info, **kwargs) -> str:
+        return EmbedBlock.resolve_raw_value(self, info, **kwargs)
 
-    def resolve_embed(self, info, **kwargs):
+    def resolve_embed(self: EmbedValue, info, **kwargs) -> Optional[str]:
         embed = get_embed_object(self)
         if embed:
             return embed.html
 
-    def resolve_raw_embed(self, info, **kwargs):
+    def resolve_raw_embed(self: EmbedValue, info, **kwargs) -> Optional[str]:
         embed = get_embed_object(self)
         if embed:
             return {

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -358,7 +358,7 @@ class EmbedBlock(graphene.ObjectType):
     def resolve_url(self, info, **kwargs):
         return get_embed_url(self)
 
-    def resolve_raw_value(self, info, **kwargs):
+    def resolve_value(self, info, **kwargs):
         if isinstance(self, EmbedValue):
             return self
         return StreamFieldInterface.resolve_raw_value(info, **kwargs)

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -481,7 +481,7 @@ class BlogTest(BaseGrappleTest):
                                 url
                                 embed
                                 rawEmbed
-                                rawValue
+                                value
                             }
                         }
                     }
@@ -506,11 +506,11 @@ class BlogTest(BaseGrappleTest):
         for block in body:
             if block["blockType"] == "VideoBlock":
                 embed = block["youtubeLink"]
-                expected_raw_value = "<div>\n    {}\n</div>\n".format(embed["embed"])
+                expected_value = "<div>\n    {}\n</div>\n".format(embed["embed"])
                 self.assertTrue(isinstance(embed["url"], str))
                 self.assertEqual(embed["embed"], raw_embed["html"])
                 self.assertEqual(embed["rawEmbed"], json.dumps(raw_embed))
-                self.assertEqual(embed["rawValue"], expected_raw_value)
+                self.assertEqual(embed["value"], expected_value)
                 return
 
         self.fail("VideoBlock type not instantiated in Streamfield")

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -482,6 +482,7 @@ class BlogTest(BaseGrappleTest):
                                 embed
                                 rawEmbed
                                 value
+                                rawValue
                             }
                         }
                     }
@@ -511,6 +512,9 @@ class BlogTest(BaseGrappleTest):
                 self.assertEqual(embed["embed"], raw_embed["html"])
                 self.assertEqual(embed["rawEmbed"], json.dumps(raw_embed))
                 self.assertEqual(embed["value"], expected_value)
+                # For now, both `value` and `raw_value` resolve to the same HTML
+                # See discussion @ https://github.com/torchbox/wagtail-grapple/pull/399#discussion_r1714917129
+                self.assertEqual(embed["rawValue"], expected_value)
                 return
 
         self.fail("VideoBlock type not instantiated in Streamfield")


### PR DESCRIPTION
Fixes #395 

This PR changes the incorrectly named `resolve_raw_value` function to `resolve_value` on `EmbedBlock`. This fixes an issue where it was impossible to query for `value` on embeds using wagtail_grapple.

