### PR TITLE
fix: rendition urls are not FQDNs

### DIFF
--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -99,7 +99,7 @@ class ImageRenditionObjectType(DjangoObjectType):
     def resolve_url(
         instance: WagtailImageRendition, info: GraphQLResolveInfo, **kwargs
     ):
-        return instance.full_url
+        return get_media_item_url(instance)
 
 
 class ImageObjectType(DjangoObjectType):


### PR DESCRIPTION
Rendition URLs are returning only a path starting in 0.20.0 This updates it to return the same fully qualified domain name as the Image URLs.  I would appreciate it if this could be backported to at least 0.20.0 to create 0.20.1 since I'm still on the 0.20.0 branch. I'm running off a fork in the mean time so not operationally impacted. 