### PR TITLE
Support for ImageBlock

### DIFF
--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -381,12 +381,22 @@ def register_streamfield_blocks():
 
         def resolve_image(self, info, **kwargs):
             return self.value
+        
+    class ImageBlock(graphene.ObjectType):
+        image = graphene.Field(get_image_type, required=False)
+
+        class Meta:
+            interfaces = (StreamFieldInterface,)
+
+        def resolve_image(self, info, **kwargs):
+            return self.value
 
     registry.streamfield_blocks.update(
         {
             blocks.PageChooserBlock: PageChooserBlock,
             wagtail.documents.blocks.DocumentChooserBlock: DocumentChooserBlock,
             wagtail.images.blocks.ImageChooserBlock: ImageChooserBlock,
+            wagtail.images.blocks.ImageBlock: ImageBlock,
         }
     )
 

--- a/tests/testapp/blocks.py
+++ b/tests/testapp/blocks.py
@@ -7,7 +7,10 @@ import graphene
 from django.utils.text import slugify
 from wagtail import blocks
 from wagtail.embeds.blocks import EmbedBlock
-from wagtail.images.blocks import ImageChooserBlock
+from wagtail.images.blocks import (
+    ImageChooserBlock, 
+    ImageBlock,
+)
 from wagtail.snippets.blocks import SnippetChooserBlock
 
 from grapple.helpers import register_streamfield_block
@@ -311,6 +314,7 @@ class StreamFieldBlock(blocks.StreamBlock):
     heading = blocks.CharBlock(classname="full title")
     paragraph = blocks.RichTextBlock()
     image = ImageChooserBlock()
+    image_with_alt = ImageBlock()
     decimal = blocks.DecimalBlock()
     date = blocks.DateBlock()
     datetime = blocks.DateTimeBlock()


### PR DESCRIPTION
While working on a project with Next.js, GraphQL, and Wagtail, I identified that Wagtail's new ImageBlock is not currently supported, hence the need to add support for it.