### PR TITLE
Upgrade to `actions/upload-artifact@v4`; fix testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         db: ['sqlite']
 
     steps:
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         db: ['postgres']
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
         run: tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.db }}
           path: tests/.coverage*
           if-no-files-found: ignore
           retention-days: 1
@@ -100,9 +100,9 @@ jobs:
         run: tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.db }}
           path: tests/.coverage*
           if-no-files-found: ignore
           retention-days: 1
@@ -122,9 +122,10 @@ jobs:
       - run: python -Im pip install --upgrade coverage[toml]
 
       - name: ⬇️ Download coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: ＋ Generate report
         run: |
@@ -133,7 +134,7 @@ jobs:
           echo "## Coverage summary" >> $GITHUB_STEP_SUMMARY
           python -Im coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
       - name: 📈 Upload HTML report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-report
           path: htmlcov

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: python -Im flit build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist
 
@@ -43,7 +43,7 @@ jobs:
       # Mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: 🚀 Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,7 @@ ruff==0.0.287
 
 # Runtime requirements
 Django>=4.2,<5.1
-wagtail>=4.1
+wagtail>=5.2,<6.3
 graphene-django>=3.0.0
 factory-boy==3.2.1
 wagtail-factories>=4.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -45,13 +45,8 @@ deps =
 
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
-    wagtail52: wagtail>=5.2,<6.0
-    wagtail60: wagtail>=6.0,<6.1
-    wagtail61: wagtail>=6.1,<6.2
     wagtail62: wagtail>=6.2,<6.3
     interactive: wagtail>=5.2
-
-install_command = python -Im pip install {opts} {packages}
 
 commands =
     python -m coverage run manage.py test {posargs: -v1} --exclude-tag=needs-custom-settings

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version = 4.0
 
 envlist =
-    py{38,39,310,311,312}-django{42}-wagtail{52,60}
-    py{310,311,312}-django{50}-wagtail{52,60}
+    py{38,39,310,311,312}-django{42}-wagtail{62}
+    py{310,311,312}-django{50}-wagtail{62}
     interactive
 
 [gh-actions]
@@ -47,9 +47,11 @@ deps =
     django50: Django>=5.0,<5.1
     wagtail52: wagtail>=5.2,<6.0
     wagtail60: wagtail>=6.0,<6.1
+    wagtail61: wagtail>=6.1,<6.2
+    wagtail62: wagtail>=6.2,<6.3
     interactive: wagtail>=5.2
 
-install_command = python -Im pip install -U {opts} {packages}
+install_command = python -Im pip install {opts} {packages}
 
 commands =
     python -m coverage run manage.py test {posargs: -v1} --exclude-tag=needs-custom-settings


### PR DESCRIPTION
CI runs are failing with this error:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

I've upgraded to v4 of the `upload-artifact` and `download-artifact` actions: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md.

One change that affects this repository is about "Multiple uploads to the same named Artifact"; the uploads need to have distinct names, and then get merged during download.