### PR TITLE
Add support for Wagtail 6.3 and 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Added
+
+-   Support for Wagtail 6.3 and 6.4 ([#416](https://github.com/torchbox/wagtail-grapple/pull/416)) @mgax
+
+### Removed
+
+-   Support for Wagtail < 6.3 ([#416](https://github.com/torchbox/wagtail-grapple/pull/416)) @mgax
+
 ## [0.27.0] - 2024-09-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Added
 
--   Support for Wagtail 6.3 and 6.4 ([#416](https://github.com/torchbox/wagtail-grapple/pull/416)) @mgax
+-   Support for Wagtail 6.3 and 6.4 and Python 3.13 ([#416](https://github.com/torchbox/wagtail-grapple/pull/416)) @mgax
 
 ### Removed
 
--   Support for Wagtail < 6.3 ([#416](https://github.com/torchbox/wagtail-grapple/pull/416)) @mgax
+-   Support for Wagtail < 6.3 and Python 3.8 ([#416](https://github.com/torchbox/wagtail-grapple/pull/416)) @mgax
 
 ## [0.27.0] - 2024-09-24
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # WARNING: THIS IS NOT FOR USE IN PRODUCTION IN ANY SHAPE OR FORM.
 
 # Use an official Python runtime as a parent image
-FROM python:3.8
+FROM python:3.9
 LABEL maintainer="hello@wagtail.io"
 
 # Set environment varibles

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Getting Grapple installed is designed to be as simple as possible!
 ### Prerequisites
 
 ```
-Python >= 3.8
-Wagtail >= 5.2
+Python >= 3.9
+Wagtail >= 6.3
 Django >= 4.2
 ```
 
@@ -181,8 +181,8 @@ Any contributions [you make](https://github.com/torchbox/wagtail-grapple/graphs/
 
 Wagtail Grapple supports:
 
--   Python 3.8, 3.9, 3.10 3.11 and 3.12
--   Wagtail >= 5.2
+-   Python 3.9, 3.10, 3.11, 3.12 and 3.13
+-   Wagtail >= 6.3
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,19 +21,18 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
 ]
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=5.2",
+    "Wagtail>=6.3",
     "graphene-django>=3,<4",
     "wagtail-headless-preview"
 ]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,7 @@ ruff==0.0.287
 
 # Runtime requirements
 Django>=4.2,<5.1
-wagtail>=5.2,<6.3
+wagtail>=6.3,<6.5
 graphene-django>=3.0.0
 factory-boy==3.2.1
 wagtail-factories>=4.1.0

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -186,13 +186,14 @@ ALLOWED_HOSTS = ["*"]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-
-with contextlib.suppress(ImportError):
-    from .local import *  # noqa: F403
-
+# Make sure the search index is updated immediately during tests
 TASKS = {
     "default": {
         "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
         "ENQUEUE_ON_COMMIT": False,
     }
 }
+
+
+with contextlib.suppress(ImportError):
+    from .local import *  # noqa: F403

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -189,3 +189,10 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 with contextlib.suppress(ImportError):
     from .local import *  # noqa: F403
+
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+        "ENQUEUE_ON_COMMIT": False,
+    }
+}

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -726,4 +726,16 @@ class Migration(migrations.Migration):
             },
             bases=(wagtail.images.models.ImageFileMixin, models.Model),
         ),
+        migrations.AddField(
+            model_name="customimage",
+            name="description",
+            field=models.CharField(
+                blank=True, default="", max_length=255, verbose_name="description"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="customdocument",
+            name="file_size",
+            field=models.PositiveBigIntegerField(editable=False, null=True),
+        ),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,18 @@
 min_version = 4.0
 
 envlist =
-    py{38,39,310,311,312}-django{42}-wagtail{62}
-    py{310,311,312}-django{50}-wagtail{62}
+    py{39,310,311,312}-django{42}-wagtail{63,64}
+    py{310,311,312}-django{50}-wagtail{63,64}
+    py{310,311,312,313}-django{51}-wagtail{63,64}
     interactive
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DB =
@@ -45,8 +46,9 @@ deps =
 
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
-    wagtail62: wagtail>=6.2,<6.3
-    interactive: wagtail>=5.2
+    django51: Django>=5.1,<5.2
+    wagtail63: wagtail>=6.3,<6.4
+    wagtail64: wagtail>=6.4,<6.5
 
 commands =
     python -m coverage run manage.py test {posargs: -v1} --exclude-tag=needs-custom-settings
@@ -73,7 +75,7 @@ description = An interactive environment for local testing purposes
 base_python = python3.11
 
 deps =
-    wagtail>=5.2
+    wagtail>=6.3
 
 commands_pre =
     python manage.py makemigrations


### PR DESCRIPTION
[Wagtail 6.3](https://docs.wagtail.org/en/stable/releases/6.3.html) has made a couple of changes to image and document models:
- Images have a new `description` field.
- Documents have their `file_size` field changed to `PositiveBigIntegerField`.

This requires a change in the migrations for the test app, which makes it incompatible with older Wagtail versions. The only older version that is still supported is Wagtail 5.2 LTS, but [only until 2025-05-01](https://github.com/wagtail/wagtail/wiki/Release-schedule#future-and-current-versions).