### PR TITLE
Support for Wagtail 4.3 ImageBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 -   Support for Wagtail 6.3 and 6.4 and Python 3.13 ([#416](https://github.com/torchbox/wagtail-grapple/pull/416)) @mgax
+-   Support for `ImageBlock` ([#419](https://github.com/torchbox/wagtail-grapple/pull/419)) @mgax
 
 ### Removed
 

--- a/docs/getting-started/examples.rst
+++ b/docs/getting-started/examples.rst
@@ -13,11 +13,13 @@ Wagtail docs:
 
 .. code-block:: python
 
-    from grapple.models import (
-        GraphQLRichText,
-        GraphQLString,
-        GraphQLStreamfield,
-    )
+    from django.db import models
+    from grapple.models import GraphQLRichText, GraphQLStreamfield, GraphQLString
+    from wagtail import blocks
+    from wagtail.models import Page
+    from wagtail.images.blocks import ImageBlock
+    from wagtail.fields import RichTextField, StreamField
+    from wagtail.admin.edit_handlers import FieldPanel
 
 
     class BlogPage(Page):
@@ -28,7 +30,7 @@ Wagtail docs:
             [
                 ("heading", blocks.CharBlock(classname="full title")),
                 ("paragraph", blocks.RichTextBlock()),
-                ("image", ImageChooserBlock()),
+                ("image", ImageBlock()),
             ]
         )
 
@@ -62,10 +64,12 @@ something like:
                 summary
                 body {
                     rawValue
-                    ...on ImageChooserBlock {
+                    ...on ImageBlock {
                         image {
                             src
                         }
+                        decorative
+                        altText
                     }
                 }
             }

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -384,12 +384,20 @@ def register_streamfield_blocks():
 
     class ImageBlock(graphene.ObjectType):
         image = graphene.Field(get_image_type, required=False)
+        decorative = graphene.Boolean(required=False)
+        alt_text = graphene.String(required=False)
 
         class Meta:
             interfaces = (StreamFieldInterface,)
 
         def resolve_image(self, info, **kwargs):
             return self.value
+
+        def resolve_decorative(self, info, **kwargs):
+            return self.value.decorative
+
+        def resolve_alt_text(self, info, **kwargs):
+            return self.value.contextual_alt_text
 
     registry.streamfield_blocks.update(
         {

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -381,12 +381,22 @@ def register_streamfield_blocks():
 
         def resolve_image(self, info, **kwargs):
             return self.value
+        
+    class ImageBlock(graphene.ObjectType):
+        image = graphene.Field(get_image_type, required=False)
+
+        class Meta:
+            interfaces = (StreamFieldInterface,)
+
+        def resolve_image(self, info, **kwargs):
+            return self.value
 
     registry.streamfield_blocks.update(
         {
             blocks.PageChooserBlock: PageChooserBlock,
             wagtail.documents.blocks.DocumentChooserBlock: DocumentChooserBlock,
             wagtail.images.blocks.ImageChooserBlock: ImageChooserBlock,
+            wagtail.images.blocks.ImageBlock: ImageBlock,
         }
     )
 

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -381,7 +381,7 @@ def register_streamfield_blocks():
 
         def resolve_image(self, info, **kwargs):
             return self.value
-        
+
     class ImageBlock(graphene.ObjectType):
         image = graphene.Field(get_image_type, required=False)
 

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -204,6 +204,7 @@ class BlogTest(BaseGrappleTest):
     def test_blog_body_charblock(self):
         block_type = "CharBlock"
         query_blocks = self.get_blocks_from_body(block_type)
+        self.assertEqual(len(query_blocks), 2)
 
         # Check output.
         count = 0
@@ -219,6 +220,7 @@ class BlogTest(BaseGrappleTest):
     def test_streamfield_richtextblock(self):
         block_type = "RichTextBlock"
         query_blocks = self.get_blocks_from_body(block_type)
+        self.assertEqual(len(query_blocks), 1)
 
         # Check the raw value.
         count = 0
@@ -298,6 +300,7 @@ class BlogTest(BaseGrappleTest):
             }
             """,
         )
+        self.assertEqual(len(query_blocks), 1)
 
         # Check output.
         count = 0
@@ -355,6 +358,7 @@ class BlogTest(BaseGrappleTest):
             altText
             """,
         )
+        self.assertEqual(len(query_blocks), 1)
 
         # Check output.
         count = 0
@@ -400,6 +404,7 @@ class BlogTest(BaseGrappleTest):
     def test_blog_body_decimalblock(self):
         block_type = "DecimalBlock"
         query_blocks = self.get_blocks_from_body(block_type)
+        self.assertEqual(len(query_blocks), 1)
 
         # Check output.
         count = 0
@@ -415,6 +420,7 @@ class BlogTest(BaseGrappleTest):
     def test_blog_body_dateblock(self):
         block_type = "DateBlock"
         query_blocks = self.get_blocks_from_body(block_type)
+        self.assertEqual(len(query_blocks), 1)
 
         # Check output.
         count = 0
@@ -434,6 +440,7 @@ class BlogTest(BaseGrappleTest):
             block_type,
             block_query=f'value(format: "{date_format_string}")',
         )
+        self.assertEqual(len(query_blocks), 1)
 
         # Check output.
         count = 0
@@ -463,6 +470,7 @@ class BlogTest(BaseGrappleTest):
             }
             """,
         )
+        self.assertEqual(len(query_blocks), 1)
 
         # Check output.
         count = 0
@@ -574,6 +582,7 @@ class BlogTest(BaseGrappleTest):
         query_blocks = self.get_blocks_from_body(
             block_type, block_query=block_query, page_id=another_blog_post.id
         )
+        self.assertEqual(len(query_blocks), 1)
 
         # Check output.
         count = 0

--- a/tests/test_models_types.py
+++ b/tests/test_models_types.py
@@ -3,7 +3,7 @@ import graphene
 from django.test import TestCase
 from wagtail.blocks.field_block import PageChooserBlock
 from wagtail.documents.blocks import DocumentChooserBlock
-from wagtail.images.blocks import ImageChooserBlock
+from wagtail.images.blocks import ImageBlock, ImageChooserBlock
 from wagtail.snippets.blocks import SnippetChooserBlock
 
 from grapple import registry
@@ -226,6 +226,18 @@ class ChooserBlocksTest(TestCase):
         schema.
         """
         block = registry.registry.streamfield_blocks[ImageChooserBlock]
+        field = block.image
+
+        # Check that field is not required by asserting type isn't `NonNull`
+        self.assertIsInstance(field, graphene.types.field.Field)
+        self.assertNotIsInstance(field.type, graphene.NonNull)
+
+    def test_image_block_value_field_not_required(self):
+        """
+        Test that the ImageBlock image field is nullable in the GraphQL
+        schema.
+        """
+        block = registry.registry.streamfield_blocks[ImageBlock]
         field = block.image
 
         # Check that field is not required by asserting type isn't `NonNull`

--- a/tests/testapp/blocks.py
+++ b/tests/testapp/blocks.py
@@ -7,7 +7,10 @@ import graphene
 from django.utils.text import slugify
 from wagtail import blocks
 from wagtail.embeds.blocks import EmbedBlock
-from wagtail.images.blocks import ImageChooserBlock
+from wagtail.images.blocks import (
+    ImageChooserBlock, 
+    ImageBlock,
+)
 from wagtail.snippets.blocks import SnippetChooserBlock
 
 from grapple.helpers import register_streamfield_block
@@ -311,6 +314,7 @@ class StreamFieldBlock(blocks.StreamBlock):
     heading = blocks.CharBlock(classname="full title")
     paragraph = blocks.RichTextBlock()
     image = ImageChooserBlock()
+    image_with_alt = ImageBlock()
     decimal = blocks.DecimalBlock()
     date = blocks.DateBlock()
     datetime = blocks.DateTimeBlock()

--- a/tests/testapp/blocks.py
+++ b/tests/testapp/blocks.py
@@ -8,8 +8,8 @@ from django.utils.text import slugify
 from wagtail import blocks
 from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images.blocks import (
-    ImageChooserBlock, 
     ImageBlock,
+    ImageChooserBlock,
 )
 from wagtail.snippets.blocks import SnippetChooserBlock
 

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -40,6 +40,18 @@ class ImageBlockFactory(wagtail_factories.StructBlockFactory):
     class Meta:
         model = image_blocks.ImageBlock
 
+    @classmethod
+    def _construct_struct_value(cls, block_class, params):
+        if image := params["image"]:
+            decorative = params["decorative"]
+            alt_text = params["alt_text"]
+
+            # If the image is decorative, set alt_text to an empty string
+            image.contextual_alt_text = "" if decorative else alt_text
+            image.decorative = decorative
+
+        return image
+
 
 class DateBlockFactory(wagtail_factories.blocks.BlockFactory):
     class Meta:

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -1,6 +1,7 @@
 import datetime
 
 import factory
+import wagtail.images.blocks as image_blocks
 import wagtail_factories
 
 from django.core.exceptions import ValidationError
@@ -28,6 +29,18 @@ from testapp.models import (
 
 
 # START: Block Factories
+
+
+# TODO: Contribute upstream to wagtail-factories
+class ImageBlockFactory(wagtail_factories.StructBlockFactory):
+    image = factory.SubFactory(wagtail_factories.ImageChooserBlockFactory)
+    decorative = factory.Faker("boolean")
+    alt_text = factory.Sequence(lambda n: f"Alt text {n}")
+
+    class Meta:
+        model = image_blocks.ImageBlock
+
+
 class DateBlockFactory(wagtail_factories.blocks.BlockFactory):
     class Meta:
         model = blocks.DateBlock
@@ -130,6 +143,7 @@ class BlogPageFactory(wagtail_factories.PageFactory):
             "heading": wagtail_factories.CharBlockFactory,
             "paragraph": RichTextBlockFactory,
             "image": wagtail_factories.ImageChooserBlockFactory,
+            "image_with_alt": ImageBlockFactory,
             "decimal": DecimalBlockFactory,
             "date": DateBlockFactory,
             "datetime": DateTimeBlockFactory,

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -31,7 +31,7 @@ from testapp.models import (
 # START: Block Factories
 
 
-# TODO: Contribute upstream to wagtail-factories
+# TODO: Contribute upstream: https://github.com/wagtail/wagtail-factories/issues/97
 class ImageBlockFactory(wagtail_factories.StructBlockFactory):
     image = factory.SubFactory(wagtail_factories.ImageChooserBlockFactory)
     decorative = factory.Faker("boolean")

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -95,21 +95,22 @@ class Migration(migrations.Migration):
                             ("heading", 0),
                             ("paragraph", 1),
                             ("image", 2),
-                            ("decimal", 3),
-                            ("date", 4),
-                            ("datetime", 5),
-                            ("gallery", 8),
-                            ("video", 10),
-                            ("objectives", 12),
-                            ("carousel", 13),
-                            ("callout", 14),
-                            ("text_and_buttons", 20),
-                            ("page", 21),
-                            ("text_with_callable", 24),
-                            ("block_with_name", 25),
-                            ("advert", 26),
-                            ("person", 27),
-                            ("additional_interface_block", 28),
+                            ("image_with_alt", 3),
+                            ("decimal", 4),
+                            ("date", 5),
+                            ("datetime", 6),
+                            ("gallery", 9),
+                            ("video", 11),
+                            ("objectives", 13),
+                            ("carousel", 14),
+                            ("callout", 15),
+                            ("text_and_buttons", 21),
+                            ("page", 22),
+                            ("text_with_callable", 25),
+                            ("block_with_name", 26),
+                            ("advert", 27),
+                            ("person", 28),
+                            ("additional_interface_block", 29),
                         ],
                         block_lookup={
                             0: (
@@ -119,93 +120,94 @@ class Migration(migrations.Migration):
                             ),
                             1: ("wagtail.blocks.RichTextBlock", (), {}),
                             2: ("wagtail.images.blocks.ImageChooserBlock", (), {}),
-                            3: ("wagtail.blocks.DecimalBlock", (), {}),
-                            4: ("wagtail.blocks.DateBlock", (), {}),
-                            5: ("wagtail.blocks.DateTimeBlock", (), {}),
-                            6: (
+                            3: ("wagtail.images.blocks.ImageBlock", [], {}),
+                            4: ("wagtail.blocks.DecimalBlock", (), {}),
+                            5: ("wagtail.blocks.DateBlock", (), {}),
+                            6: ("wagtail.blocks.DateTimeBlock", (), {}),
+                            7: (
                                 "wagtail.blocks.StructBlock",
                                 [[("caption", 0), ("image", 2)]],
                                 {},
                             ),
-                            7: ("wagtail.blocks.StreamBlock", [[("image", 6)]], {}),
-                            8: (
+                            8: ("wagtail.blocks.StreamBlock", [[("image", 7)]], {}),
+                            9: (
                                 "wagtail.blocks.StructBlock",
-                                [[("title", 0), ("images", 7)]],
+                                [[("title", 0), ("images", 8)]],
                                 {},
                             ),
-                            9: (
+                            10: (
                                 "wagtail.embeds.blocks.EmbedBlock",
                                 (),
                                 {"required": False},
                             ),
-                            10: (
+                            11: (
                                 "wagtail.blocks.StructBlock",
-                                [[("youtube_link", 9)]],
+                                [[("youtube_link", 10)]],
                                 {},
                             ),
-                            11: ("wagtail.blocks.CharBlock", (), {}),
-                            12: ("wagtail.blocks.ListBlock", (11,), {}),
-                            13: (
+                            12: ("wagtail.blocks.CharBlock", (), {}),
+                            13: ("wagtail.blocks.ListBlock", (12,), {}),
+                            14: (
                                 "wagtail.blocks.StreamBlock",
                                 [[("text", 0), ("image", 2), ("markup", 1)]],
                                 {},
                             ),
-                            14: (
+                            15: (
                                 "wagtail.blocks.StructBlock",
                                 [[("text", 1), ("image", 2)]],
                                 {},
                             ),
-                            15: ("wagtail.blocks.TextBlock", (), {}),
-                            16: (
+                            16: ("wagtail.blocks.TextBlock", (), {}),
+                            17: (
                                 "wagtail.blocks.CharBlock",
                                 (),
                                 {"label": "Text", "max_length": 50, "required": True},
                             ),
-                            17: (
+                            18: (
                                 "wagtail.blocks.CharBlock",
                                 (),
                                 {"label": "Link", "max_length": 255, "required": True},
                             ),
-                            18: (
+                            19: (
                                 "wagtail.blocks.StructBlock",
-                                [[("button_text", 16), ("button_link", 17)]],
+                                [[("button_text", 17), ("button_link", 18)]],
                                 {},
                             ),
-                            19: ("wagtail.blocks.ListBlock", (18,), {}),
-                            20: (
+                            20: ("wagtail.blocks.ListBlock", (19,), {}),
+                            21: (
                                 "wagtail.blocks.StructBlock",
-                                [[("text", 15), ("buttons", 19), ("mainbutton", 18)]],
+                                [[("text", 16), ("buttons", 20), ("mainbutton", 19)]],
                                 {},
                             ),
-                            21: ("wagtail.blocks.PageChooserBlock", (), {}),
-                            22: ("wagtail.blocks.IntegerBlock", (), {}),
-                            23: ("wagtail.blocks.FloatBlock", (), {}),
-                            24: (
+                            22: ("wagtail.blocks.PageChooserBlock", (), {}),
+                            23: ("wagtail.blocks.IntegerBlock", (), {}),
+                            24: ("wagtail.blocks.FloatBlock", (), {}),
+                            25: (
                                 "wagtail.blocks.StructBlock",
                                 [
                                     [
-                                        ("text", 11),
-                                        ("integer", 22),
-                                        ("decimal", 23),
-                                        ("page", 21),
+                                        ("text", 12),
+                                        ("integer", 23),
+                                        ("decimal", 24),
+                                        ("page", 22),
                                     ]
                                 ],
                                 {},
                             ),
-                            25: ("wagtail.blocks.StructBlock", [[("name", 15)]], {}),
-                            26: (
+                            26: ("wagtail.blocks.StructBlock", [[("name", 16)]], {}),
+                            27: (
                                 "wagtail.snippets.blocks.SnippetChooserBlock",
                                 ("testapp.Advert",),
                                 {},
                             ),
-                            27: (
+                            28: (
                                 "wagtail.snippets.blocks.SnippetChooserBlock",
                                 ("testapp.Person",),
                                 {},
                             ),
-                            28: (
+                            29: (
                                 "wagtail.blocks.StructBlock",
-                                [[("additional_text", 15)]],
+                                [[("additional_text", 16)]],
                                 {},
                             ),
                         },


### PR DESCRIPTION
https://docs.wagtail.org/en/stable/releases/6.3.html#imageblock-with-alt-text-support

This PR is based on https://github.com/torchbox/wagtail-grapple/pull/411, with:
- [x] Added fields (`decorative` and `altText`)
- [x] Tests
- [x] Update of the initial migration
- [x] Changelog entry
- [x] Documentation
