### PR TITLE
Expand uv usage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ env:
   TOX_TESTENV_PASSENV: FORCE_COLOR
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
-  # Keep in sync with .pre-commit-config.yaml/default_language_version/python.
-  PYTHON_LATEST: "3.11"
+  PYTHON_LATEST: "3.13"
 
 jobs:
   tests-sqlite:
@@ -27,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.12']
         db: ['sqlite']
 
     steps:
@@ -60,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         db: ['postgres']
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [PYTHON_LATEST]
+        python-version: ["3.13"]
         db: ['sqlite']
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           uvx coverage html --skip-covered --skip-empty
           uvx coverage report
           echo "## Coverage summary" >> $GITHUB_STEP_SUMMARY
-          python -Im coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+          uvx coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
       - name: 📈 Upload HTML report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']
+        python-version: [PYTHON_LATEST]
         db: ['sqlite']
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,11 @@ jobs:
         db: ['sqlite']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -75,9 +77,11 @@ jobs:
         options: --health-cmd "pg_isready -d postgres -U postgres -p 5432" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -106,8 +110,10 @@ jobs:
     needs: [tests-sqlite, tests-postgres]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
         with:
           # Use latest Python, so it understands all syntax.
           python-version: ${{env.PYTHON_LATEST}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: uvx flit build --format wheel
 
       - name: 🧪 Run tox targets for Python ${{ matrix.python-version }}
-        run: uvx --with tox-uv,tox-gh-actions tox --installpkg ./dist/*.whl
+        run: uvx --with tox-uv --with tox-gh-actions tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data
         uses: actions/upload-artifact@v4
@@ -91,7 +91,7 @@ jobs:
       - name: 🧪 Run tox targets for Python ${{ matrix.python-version }}
         env:
           DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/postgres'
-        run: uvx --with tox-uv,tox-gh-actions tox --installpkg ./dist/*.whl
+        run: uvx --with tox-uv --with tox-gh-actions tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data
         uses: actions/upload-artifact@v4
@@ -113,7 +113,8 @@ jobs:
           # Use latest Python, so it understands all syntax.
           python-version: ${{env.PYTHON_LATEST}}
 
-      - run: python -Im pip install --upgrade coverage[toml]
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
 
       - name: ⬇️ Download coverage data
         uses: actions/download-artifact@v4
@@ -123,8 +124,8 @@ jobs:
 
       - name: ＋ Generate report
         run: |
-          python -Im coverage html --skip-covered --skip-empty
-          python -Im coverage report
+          uvx coverage html --skip-covered --skip-empty
+          uvx coverage report
           echo "## Coverage summary" >> $GITHUB_STEP_SUMMARY
           python -Im coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
       - name: 📈 Upload HTML report

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,17 +16,15 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: '**/pyproject.toml'
 
-      - name: ⬇️ Install dependencies
-        run: |
-          python -Im pip install --upgrade pip
-          python -Im pip install "flit>=3.8.0"
-          python -Im flit install --symlink
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
+
       - name: Build
-        run: python -Im flit build
+        run: uvx flit build
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           cache: 'pip'

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # keep in sync with .pre-commit-config.yaml and tests/requirements.txt
     - run: python -Im pip install --user ruff==0.9.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 testing = [
-    "coverage[toml]>=7.2.7,<8.0",
+    "coverage>=7.2.7,<8.0",
 ]
 
 docs = [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ min_version = 4.0
 
 envlist =
     py{39,310,311,312}-django{42}-wagtail{63,64}
-    py{310,311,312}-django{50}-wagtail{63,64}
+    py{312}-django{50}-wagtail{63}
     py{310,311,312,313}-django{51}-wagtail{63,64}
     interactive
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ change_dir = {tox_root}/tests
 
 deps =
     flit>=3.8
-    coverage[toml]>=7.0,<8.0
+    coverage>=7.0,<8.0
     factory-boy==3.2.1
     wagtail-factories>=4.1.0
     django-cors-headers==3.4.0
@@ -57,7 +57,7 @@ commands =
 [testenv:coverage-report]
 ; a bit of a hack - we keep deps to a minimum, and move coverage data to the tox root for easier excludes
 deps =
-install_command = python -Im pip install -U "coverage[toml]>=7.0,<8.0"
+install_command = python -Im pip install -U "coverage>=7.0,<8.0"
 change_dir = {tox_root}
 allowlist_externals = mv
 pre_commands =


### PR DESCRIPTION
- uses one `--with` per extra dependency as per https://docs.astral.sh/uv/guides/scripts/#running-a-script-with-dependencies ("Multiple dependencies can be requested by repeating with `--with` option.")
- switches the coverage step to uv (and drops the toml dep)
- uses uv in the publish workflow
- tidies up the test matrix (actually test with Python 3.13 in CI, reduce variations for sqlite)