### PR TITLE
Remove the caching config on the build job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-          cache: 'pip'
-          cache-dependency-path: '**/pyproject.toml'
 
       - name: Install uv
         uses: hynek/setup-cached-uv@v2


### PR DESCRIPTION
The _publish_ pipeline [failed](https://github.com/torchbox/wagtail-grapple/actions/runs/13387713099/job/37388140207#step:11:2) with the following error:

> Error: Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.

The cache is likely empty because we're using `hynek/setup-cached-uv@v2` to install packages, which does its own caching, so I've removed the offending cache step.