### PR TITLE
Fix DjangoObjectType deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- Declare explicit `fields`/`exclude` on `DjangoObjectType` subclasses to silence graphene-django deprecation warnings ([#430](https://github.com/torchbox/wagtail-grapple/pull/430)) @ponas
+
 ## [0.31.0] - 2026-04-21
 
 ### Added

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -312,7 +312,7 @@ def load_type_fields():
 
                 type_meta = {"Meta": Meta, "id": graphene.ID(), "name": type_name}
 
-                exclude_fields = []
+                exclude = []
                 base_type_for_exclusion_checks = (
                     base_type if not issubclass(cls, WagtailPage) else WagtailPage
                 )
@@ -327,7 +327,7 @@ def load_type_fields():
                     ):
                         continue
 
-                    exclude_fields.append(field)
+                    exclude.append(field)
 
                 # Add any custom fields to node if they are defined.
                 methods = {}
@@ -341,14 +341,14 @@ def load_type_fields():
                         type_meta[field.field_name] = field_type
 
                         # Remove field from excluded list
-                        if field.field_name in exclude_fields:
-                            exclude_fields.remove(field.field_name)
+                        if field.field_name in exclude:
+                            exclude.remove(field.field_name)
 
                         # Add a custom resolver for each field
                         methods[f"resolve_{field.field_name}"] = model_resolver(field)
 
                 # Replace stud node with real thing
-                type_meta["Meta"].exclude_fields = exclude_fields
+                type_meta["Meta"].exclude = exclude
                 node = type(type_name, (base_type,), type_meta)
 
                 # Add custom resolvers for fields

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -267,6 +267,7 @@ def build_node_type(
 
     class StubMeta:
         model = stub_model
+        fields = "__all__"
 
     # Gather any interfaces, and discard None values
     interface_classes = getattr(cls, "graphql_interfaces", ())

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -15,6 +15,7 @@ class CollectionObjectType(DjangoObjectType):
 
     class Meta:
         model = Collection
+        fields = "__all__"
 
     id = graphene.ID(required=True)
     name = graphene.String(required=True)

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -38,6 +38,7 @@ class DocumentObjectType(DjangoObjectType):
 
     class Meta:
         model = WagtailDocument
+        fields = "__all__"
 
 
 def get_document_type():

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -95,6 +95,7 @@ class ImageRenditionObjectType(DjangoObjectType):
 
     class Meta:
         model = WagtailImageRendition
+        fields = "__all__"
 
     def resolve_url(
         instance: WagtailImageRendition, info: GraphQLResolveInfo, **kwargs
@@ -127,6 +128,7 @@ class ImageObjectType(DjangoObjectType):
 
     class Meta:
         model = WagtailImage
+        fields = "__all__"
 
     def resolve_rendition(
         instance: WagtailImage, info: GraphQLResolveInfo, **kwargs

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -23,6 +23,7 @@ class Page(DjangoObjectType):
     class Meta:
         model = WagtailPage
         interfaces = (get_page_interface(),)
+        fields = "__all__"
 
 
 def get_preview_page(token):

--- a/grapple/types/sites.py
+++ b/grapple/types/sites.py
@@ -64,6 +64,7 @@ class SiteObjectType(DjangoObjectType):
 
     class Meta:
         model = Site
+        fields = "__all__"
 
 
 def SitesQuery():


### PR DESCRIPTION
The following warnings were emitted from `graphene-django`:

```
DeprecationWarning: Creating a DjangoObjectType without either the `fields` or the `exclude` option is deprecated. Add an explicit `fields = '__all__'` option on DjangoObjectType CollectionObjectType to use all fields
DeprecationWarning: Defining `exclude_fields` is deprecated in favour of `exclude`.
```

Fixed by:
* explicitly setting `fields = "__all__"`
* setting `exclude` instead of `exclude_fields`

Closes #355