### PR TITLE
chore: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: 🐞 Bug report
+description: Found a bug? Let us know so we can fix it 👍
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Before submitting, please search the [existing issues](https://github.com/torchbox/wagtail-grapple/issues) to check it hasn't already been reported.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Issue summary
+      description: A clear and concise summary of the bug.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Detailed steps to reproduce the behaviour. Where possible, include the relevant model / `graphql_fields` definitions and the GraphQL query.
+      value: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: Tell us what you expected, and why you consider the current behaviour a bug.
+    validations:
+      required: false
+
+  - type: input
+    id: grapple-version
+    attributes:
+      label: wagtail-grapple version
+      description: Run `pip show wagtail-grapple | grep Version`.
+    validations:
+      required: true
+
+  - type: input
+    id: wagtail-version
+    attributes:
+      label: Wagtail version
+      description: Run `pip show wagtail | grep Version`.
+    validations:
+      required: true
+
+  - type: input
+    id: django-version
+    attributes:
+      label: Django version
+      description: Run `pip show django | grep Version`.
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Run `python --version`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional information
+      description: Any other relevant information — `graphene` / `graphene-django` versions, tracebacks, screenshots, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Question or discussion
+    url: https://github.com/torchbox/wagtail-grapple/discussions
+    about: Use GitHub Discussions to ask questions or get help with Wagtail Grapple.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: 🚀 Feature request
+description: Suggest an idea or improvement for Wagtail Grapple
+labels: ['type: Enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+
+        Please search the [existing issues](https://github.com/torchbox/wagtail-grapple/issues) first to avoid duplicates.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your proposal related to a problem?
+      description: A clear and concise description of the problem. For example, "I'm always frustrated when..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else to add? Link related issues here if you haven't already.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!-- Thanks for contributing to Wagtail Grapple! -->
+
+## Description
+
+<!--
+Describe what this pull request changes and why, with enough detail for a
+reviewer to verify your work. Pull requests without an adequate description
+may not be reviewed until one is added.
+-->
+
+Fixes #<!-- issue number, if applicable -->
+
+### AI usage
+
+<!-- Please give details of any AI assistance used for this PR — including for
+writing this description — or "None" if no AI has been used. -->
+
+## Checklist
+
+- [ ] **I have added a `CHANGELOG.md` entry** under the `## Unreleased`
+      heading, in the relevant `Added` / `Changed` / `Fixed` / `Removed` section
+- [ ] I have performed a self-review of my own code
+- [ ] I have added or updated tests covering my change (or explained why not)
+- [ ] New and existing tests pass locally (`python manage.py test` from
+      `tests/`, against both SQLite and Postgres where relevant)
+- [ ] Linting and pre-commit checks pass (`pre-commit run --all-files`)
+- [ ] I have updated the documentation in `docs/` where applicable
+
+<!--
+CHANGELOG entry format (see existing entries in CHANGELOG.md):
+
+    - Short description of the change ([#PR](https://github.com/torchbox/wagtail-grapple/pull/PR)) @your-username
+
+Add an "## Unreleased" heading with the appropriate subsection if one is not
+already present.
+-->


### PR DESCRIPTION
## Description

Adds GitHub contribution templates so issues and pull requests follow a consistent structure:

- **`.github/PULL_REQUEST_TEMPLATE.md`** — description + `Fixes #`, an AI-usage disclosure section, and a checklist that puts updating `CHANGELOG.md` first, alongside tests (`python manage.py test` from `tests/`, SQLite + Postgres) and `pre-commit run --all-files`.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — YAML issue form requiring a summary, repro steps and the wagtail-grapple / Wagtail / Django / Python versions.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — YAML form (problem / solution / alternatives / context).
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues and routes questions to GitHub Discussions.

Conventions are based on the closest sibling repo (`torchbox/django-pattern-library`), with the AI-usage section and YAML issue-form style adopted from `wagtail/wagtail`. Labels used (`bug`, `type: Enhancement`) already exist in this repo.

Fixes #<!-- n/a -->

### AI usage

Authored with assistance from Claude Code (Opus 4.8), including this description. All conventions were verified against the referenced repositories, and the templates were validated against the repo's pre-commit hooks.

## Checklist

- [ ] ~~I have added a `CHANGELOG.md` entry~~ — N/A: this is repository tooling, not a user-facing library change. The changelog tracks package behaviour only.
- [x] I have performed a self-review of my own code
- [x] ~~I have added or updated tests~~ — N/A: no testable code; templates validated via `pre-commit`/`check-yaml`.
- [x] New and existing tests pass locally (no code changed; `pre-commit run --files` passes on all four files)
- [x] Linting and pre-commit checks pass (`pre-commit run --all-files`)
- [ ] ~~I have updated the documentation in `docs/`~~ — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)